### PR TITLE
Optimize chat section part appending

### DIFF
--- a/packages/react/dist/index.d.cts
+++ b/packages/react/dist/index.d.cts
@@ -1,4 +1,4 @@
-import { ToolResult, DistriFnTool, DistriBaseTool, ToolCall, Agent as Agent$1, DistriChatMessage, ToolsConfig as ToolsConfig$1, DistriPart, AgentDefinition, DistriThread, DistriMessage, DistriEvent, DistriClientConfig, DistriClient, DistriArtifact, ImagePart } from '@distri/core';
+import { ToolResult, DistriFnTool, DistriBaseTool, ToolCall, Agent as Agent$1, DistriChatMessage, ToolsConfig, DistriPart, AgentDefinition, DistriThread, DistriMessage, DistriEvent, DistriClientConfig, DistriClient, DistriArtifact, ImagePart } from '@distri/core';
 import * as React$1 from 'react';
 import React__default, { ReactNode } from 'react';
 import * as react_jsx_runtime from 'react/jsx-runtime';
@@ -54,10 +54,6 @@ type UiToolProps = {
     completeTool: (result: ToolResult) => void;
     tool: DistriBaseTool;
 };
-type ToolsConfig = {
-    tools: DistriAnyTool[];
-    agent_tools: Map<string, DistriAnyTool[]>;
-};
 
 interface WrapToolOptions {
     autoExecute?: boolean;
@@ -77,7 +73,7 @@ interface UseChatOptions {
     onMessage?: (message: DistriChatMessage) => void;
     onError?: (error: Error) => void;
     getMetadata?: () => Promise<Record<string, unknown>>;
-    tools?: ToolsConfig$1;
+    tools?: ToolsConfig;
     wrapOptions?: WrapToolOptions;
     initialMessages?: (DistriChatMessage)[];
 }
@@ -142,7 +138,7 @@ interface ChatProps {
     beforeSendMessage?: (content: string | DistriPart[]) => Promise<string | DistriPart[]>;
     onError?: (error: Error) => void;
     getMetadata?: () => Promise<any>;
-    tools?: ToolsConfig$1;
+    tools?: ToolsConfig;
     wrapOptions?: WrapToolOptions;
     initialMessages?: (DistriChatMessage)[];
     theme?: 'light' | 'dark' | 'auto';
@@ -487,7 +483,7 @@ interface AssistantMessageRendererProps {
     avatar?: React__default.ReactNode;
     name?: string;
 }
-declare const AssistantMessageRenderer: React__default.FC<AssistantMessageRendererProps>;
+declare const AssistantMessageRenderer: React__default.NamedExoticComponent<AssistantMessageRendererProps>;
 
 interface DebugRendererProps {
     message: DistriEvent | DistriArtifact;
@@ -514,7 +510,8 @@ interface MessageRendererProps {
     isExpanded?: boolean;
     onToggle?: () => void;
 }
-declare function MessageRenderer({ message, index, isExpanded, onToggle }: MessageRendererProps): React__default.ReactNode;
+declare function MessageRendererBase({ message, index, isExpanded, onToggle }: MessageRendererProps): React__default.ReactNode;
+declare const MessageRenderer: React__default.MemoExoticComponent<typeof MessageRendererBase>;
 
 interface PlanRendererProps {
     message: DistriArtifact;
@@ -539,7 +536,7 @@ interface StreamingTextRendererProps {
     isStreaming?: boolean;
     className?: string;
 }
-declare const StreamingTextRenderer: React__default.FC<StreamingTextRendererProps>;
+declare const StreamingTextRenderer: React__default.NamedExoticComponent<StreamingTextRendererProps>;
 
 interface ExtractedContent {
     text: string;
@@ -590,4 +587,4 @@ interface UserMessageRendererProps {
 }
 declare const UserMessageRenderer: React__default.FC<UserMessageRendererProps>;
 
-export { AgentSelect, AppSidebar, ArtifactRenderer, type ArtifactRendererProps, AssistantMessageRenderer, type AssistantMessageRendererProps, type AttachedImage, Badge, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Chat, ChatInput, type ChatInputProps, type ChatProps, DebugRenderer, type DebugRendererProps, DialogRoot as Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, type DistriAnyTool, DistriProvider, type DistriUiTool, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, type ExtractedContent, ImageRenderer, type ImageRendererProps, Input, LoadingShimmer, MessageRenderer, type MessageRendererProps, type ModelOption, PlanRenderer, type PlanRendererProps, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, Separator, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarInset, SidebarMenu, SidebarMenuAction, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarMenuSkeleton, SidebarMenuSub, SidebarMenuSubButton, SidebarMenuSubItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger, Skeleton, StepBasedRenderer, type StepBasedRendererProps, StepRenderer, type StepRendererProps, type StreamDebugOptions, type StreamingIndicator, StreamingTextRenderer, TaskExecutionRenderer, Textarea, ThemeProvider, ThemeToggle, ThinkingRenderer, type ThinkingRendererProps, ToolCallRenderer, type ToolCallRendererProps, type ToolCallStatus, ToolMessageRenderer, type ToolMessageRendererProps, ToolResultRenderer, type ToolsConfig, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TypingIndicator, type UiToolProps, type UseAgentOptions, type UseAgentResult, type UseAgentsResult, type UseChatMessagesOptions, type UseChatMessagesReturn, type UseChatOptions, type UseChatReturn, type UseThreadMessagesOptions, type UseThreadsResult, UserMessageRenderer, type UserMessageRendererProps, type WrapToolOptions, debugStreamEvents, extractContent, quickDebugMessage, renderTextContent, useAgent, useAgentDefinitions, useChat, useChatMessages, useDistri, useDistriClient, useSidebar, useTheme, useThreads, wrapFnToolAsUiTool, wrapTools };
+export { AgentSelect, AppSidebar, ArtifactRenderer, type ArtifactRendererProps, AssistantMessageRenderer, type AssistantMessageRendererProps, type AttachedImage, Badge, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Chat, ChatInput, type ChatInputProps, type ChatProps, DebugRenderer, type DebugRendererProps, DialogRoot as Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, type DistriAnyTool, DistriProvider, type DistriUiTool, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, type ExtractedContent, ImageRenderer, type ImageRendererProps, Input, LoadingShimmer, MessageRenderer, type MessageRendererProps, type ModelOption, PlanRenderer, type PlanRendererProps, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, Separator, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarInset, SidebarMenu, SidebarMenuAction, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarMenuSkeleton, SidebarMenuSub, SidebarMenuSubButton, SidebarMenuSubItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger, Skeleton, StepBasedRenderer, type StepBasedRendererProps, StepRenderer, type StepRendererProps, type StreamDebugOptions, type StreamingIndicator, StreamingTextRenderer, TaskExecutionRenderer, Textarea, ThemeProvider, ThemeToggle, ThinkingRenderer, type ThinkingRendererProps, ToolCallRenderer, type ToolCallRendererProps, type ToolCallStatus, ToolMessageRenderer, type ToolMessageRendererProps, ToolResultRenderer, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TypingIndicator, type UiToolProps, type UseAgentOptions, type UseAgentResult, type UseAgentsResult, type UseChatMessagesOptions, type UseChatMessagesReturn, type UseChatOptions, type UseChatReturn, type UseThreadMessagesOptions, type UseThreadsResult, UserMessageRenderer, type UserMessageRendererProps, type WrapToolOptions, debugStreamEvents, extractContent, quickDebugMessage, renderTextContent, useAgent, useAgentDefinitions, useChat, useChatMessages, useDistri, useDistriClient, useSidebar, useTheme, useThreads, wrapFnToolAsUiTool, wrapTools };

--- a/packages/react/dist/index.d.ts
+++ b/packages/react/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { ToolResult, DistriFnTool, DistriBaseTool, ToolCall, Agent as Agent$1, DistriChatMessage, ToolsConfig as ToolsConfig$1, DistriPart, AgentDefinition, DistriThread, DistriMessage, DistriEvent, DistriClientConfig, DistriClient, DistriArtifact, ImagePart } from '@distri/core';
+import { ToolResult, DistriFnTool, DistriBaseTool, ToolCall, Agent as Agent$1, DistriChatMessage, ToolsConfig, DistriPart, AgentDefinition, DistriThread, DistriMessage, DistriEvent, DistriClientConfig, DistriClient, DistriArtifact, ImagePart } from '@distri/core';
 import * as React$1 from 'react';
 import React__default, { ReactNode } from 'react';
 import * as react_jsx_runtime from 'react/jsx-runtime';
@@ -54,10 +54,6 @@ type UiToolProps = {
     completeTool: (result: ToolResult) => void;
     tool: DistriBaseTool;
 };
-type ToolsConfig = {
-    tools: DistriAnyTool[];
-    agent_tools: Map<string, DistriAnyTool[]>;
-};
 
 interface WrapToolOptions {
     autoExecute?: boolean;
@@ -77,7 +73,7 @@ interface UseChatOptions {
     onMessage?: (message: DistriChatMessage) => void;
     onError?: (error: Error) => void;
     getMetadata?: () => Promise<Record<string, unknown>>;
-    tools?: ToolsConfig$1;
+    tools?: ToolsConfig;
     wrapOptions?: WrapToolOptions;
     initialMessages?: (DistriChatMessage)[];
 }
@@ -142,7 +138,7 @@ interface ChatProps {
     beforeSendMessage?: (content: string | DistriPart[]) => Promise<string | DistriPart[]>;
     onError?: (error: Error) => void;
     getMetadata?: () => Promise<any>;
-    tools?: ToolsConfig$1;
+    tools?: ToolsConfig;
     wrapOptions?: WrapToolOptions;
     initialMessages?: (DistriChatMessage)[];
     theme?: 'light' | 'dark' | 'auto';
@@ -487,7 +483,7 @@ interface AssistantMessageRendererProps {
     avatar?: React__default.ReactNode;
     name?: string;
 }
-declare const AssistantMessageRenderer: React__default.FC<AssistantMessageRendererProps>;
+declare const AssistantMessageRenderer: React__default.NamedExoticComponent<AssistantMessageRendererProps>;
 
 interface DebugRendererProps {
     message: DistriEvent | DistriArtifact;
@@ -514,7 +510,8 @@ interface MessageRendererProps {
     isExpanded?: boolean;
     onToggle?: () => void;
 }
-declare function MessageRenderer({ message, index, isExpanded, onToggle }: MessageRendererProps): React__default.ReactNode;
+declare function MessageRendererBase({ message, index, isExpanded, onToggle }: MessageRendererProps): React__default.ReactNode;
+declare const MessageRenderer: React__default.MemoExoticComponent<typeof MessageRendererBase>;
 
 interface PlanRendererProps {
     message: DistriArtifact;
@@ -539,7 +536,7 @@ interface StreamingTextRendererProps {
     isStreaming?: boolean;
     className?: string;
 }
-declare const StreamingTextRenderer: React__default.FC<StreamingTextRendererProps>;
+declare const StreamingTextRenderer: React__default.NamedExoticComponent<StreamingTextRendererProps>;
 
 interface ExtractedContent {
     text: string;
@@ -590,4 +587,4 @@ interface UserMessageRendererProps {
 }
 declare const UserMessageRenderer: React__default.FC<UserMessageRendererProps>;
 
-export { AgentSelect, AppSidebar, ArtifactRenderer, type ArtifactRendererProps, AssistantMessageRenderer, type AssistantMessageRendererProps, type AttachedImage, Badge, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Chat, ChatInput, type ChatInputProps, type ChatProps, DebugRenderer, type DebugRendererProps, DialogRoot as Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, type DistriAnyTool, DistriProvider, type DistriUiTool, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, type ExtractedContent, ImageRenderer, type ImageRendererProps, Input, LoadingShimmer, MessageRenderer, type MessageRendererProps, type ModelOption, PlanRenderer, type PlanRendererProps, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, Separator, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarInset, SidebarMenu, SidebarMenuAction, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarMenuSkeleton, SidebarMenuSub, SidebarMenuSubButton, SidebarMenuSubItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger, Skeleton, StepBasedRenderer, type StepBasedRendererProps, StepRenderer, type StepRendererProps, type StreamDebugOptions, type StreamingIndicator, StreamingTextRenderer, TaskExecutionRenderer, Textarea, ThemeProvider, ThemeToggle, ThinkingRenderer, type ThinkingRendererProps, ToolCallRenderer, type ToolCallRendererProps, type ToolCallStatus, ToolMessageRenderer, type ToolMessageRendererProps, ToolResultRenderer, type ToolsConfig, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TypingIndicator, type UiToolProps, type UseAgentOptions, type UseAgentResult, type UseAgentsResult, type UseChatMessagesOptions, type UseChatMessagesReturn, type UseChatOptions, type UseChatReturn, type UseThreadMessagesOptions, type UseThreadsResult, UserMessageRenderer, type UserMessageRendererProps, type WrapToolOptions, debugStreamEvents, extractContent, quickDebugMessage, renderTextContent, useAgent, useAgentDefinitions, useChat, useChatMessages, useDistri, useDistriClient, useSidebar, useTheme, useThreads, wrapFnToolAsUiTool, wrapTools };
+export { AgentSelect, AppSidebar, ArtifactRenderer, type ArtifactRendererProps, AssistantMessageRenderer, type AssistantMessageRendererProps, type AttachedImage, Badge, Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Chat, ChatInput, type ChatInputProps, type ChatProps, DebugRenderer, type DebugRendererProps, DialogRoot as Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, type DistriAnyTool, DistriProvider, type DistriUiTool, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, type ExtractedContent, ImageRenderer, type ImageRendererProps, Input, LoadingShimmer, MessageRenderer, type MessageRendererProps, type ModelOption, PlanRenderer, type PlanRendererProps, Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue, Separator, Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarInset, SidebarMenu, SidebarMenuAction, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarMenuSkeleton, SidebarMenuSub, SidebarMenuSubButton, SidebarMenuSubItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger, Skeleton, StepBasedRenderer, type StepBasedRendererProps, StepRenderer, type StepRendererProps, type StreamDebugOptions, type StreamingIndicator, StreamingTextRenderer, TaskExecutionRenderer, Textarea, ThemeProvider, ThemeToggle, ThinkingRenderer, type ThinkingRendererProps, ToolCallRenderer, type ToolCallRendererProps, type ToolCallStatus, ToolMessageRenderer, type ToolMessageRendererProps, ToolResultRenderer, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TypingIndicator, type UiToolProps, type UseAgentOptions, type UseAgentResult, type UseAgentsResult, type UseChatMessagesOptions, type UseChatMessagesReturn, type UseChatOptions, type UseChatReturn, type UseThreadMessagesOptions, type UseThreadsResult, UserMessageRenderer, type UserMessageRendererProps, type WrapToolOptions, debugStreamEvents, extractContent, quickDebugMessage, renderTextContent, useAgent, useAgentDefinitions, useChat, useChatMessages, useDistri, useDistriClient, useSidebar, useTheme, useThreads, wrapFnToolAsUiTool, wrapTools };

--- a/packages/react/src/components/renderers/AssistantMessageRenderer.tsx
+++ b/packages/react/src/components/renderers/AssistantMessageRenderer.tsx
@@ -13,7 +13,7 @@ export interface AssistantMessageRendererProps {
   name?: string;
 }
 
-export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> = ({
+const AssistantMessageRendererBase: React.FC<AssistantMessageRendererProps> = ({
   message,
   className = '',
 }) => {
@@ -43,4 +43,21 @@ export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> =
       </div>
     </div>
   );
-}; 
+};
+
+export const AssistantMessageRenderer = React.memo(AssistantMessageRendererBase, (prev, next) => {
+  const prevMsg = prev.message as any;
+  const nextMsg = next.message as any;
+  const prevText = (prevMsg?.parts || [])
+    .filter((p: any) => p?.type === 'text')
+    .map((p: any) => p.data || '')
+    .join('');
+  const nextText = (nextMsg?.parts || [])
+    .filter((p: any) => p?.type === 'text')
+    .map((p: any) => p.data || '')
+    .join('');
+
+  if (prevText !== nextText) return false;
+  if (prev.className !== next.className) return false;
+  return true;
+}); 

--- a/packages/react/src/components/renderers/StreamingTextRenderer.tsx
+++ b/packages/react/src/components/renderers/StreamingTextRenderer.tsx
@@ -58,7 +58,7 @@ interface StreamingTextRendererProps {
   className?: string;
 }
 
-export const StreamingTextRenderer: React.FC<StreamingTextRendererProps> = ({
+const StreamingTextRendererBase: React.FC<StreamingTextRendererProps> = ({
   text,
   isStreaming = false,
   className = ""
@@ -216,5 +216,9 @@ export const StreamingTextRenderer: React.FC<StreamingTextRendererProps> = ({
     </div>
   );
 };
+
+export const StreamingTextRenderer = React.memo(StreamingTextRendererBase, (prev, next) => {
+  return prev.text === next.text && prev.isStreaming === next.isStreaming && prev.className === next.className;
+});
 
 export default StreamingTextRenderer;


### PR DESCRIPTION
Optimize chat rendering and scrolling to prevent full re-renders and improve performance during message streaming.

The previous implementation caused the entire chat section to re-render on every new part addition, especially problematic with `scrollToBottom`. This PR introduces memoization for chat message components (`MessageRenderer`, `AssistantMessageRenderer`, `StreamingTextRenderer`) and updates the store to ensure immutable message updates, allowing React to efficiently re-render only the changed message parts. Additionally, auto-scrolling is now conditional and instantaneous when near the bottom, reducing layout thrashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-250d859f-7e79-4ddc-9242-c6b4160f63fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-250d859f-7e79-4ddc-9242-c6b4160f63fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

