### PR TITLE
Add thread reattachment for background tasks

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -187,6 +187,36 @@ export class Agent {
   }
 
   /**
+   * Resubscribe to an existing task's event stream and yield decoded
+   * events. Use this when reopening a thread whose task is still
+   * running in the background on the server — reported via
+   * `Thread.active_task_id` from `client.getThread`.
+   *
+   * Unlike `invokeStream`, this does not send a new message; it just
+   * reattaches to an in-flight task.
+   */
+  public async resubscribeStream(taskId: string): Promise<AsyncGenerator<DistriChatMessage>> {
+    const a2aStream = this.client.resubscribeTask(this.agentDefinition.name, taskId);
+    return (async function* () {
+      try {
+        for await (const event of a2aStream) {
+          const converted = decodeA2AStreamEvent(event);
+          if (converted) {
+            yield converted;
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const runError: RunErrorEvent = {
+          type: 'run_error',
+          data: { message, code: 'RESUBSCRIBE_ERROR' },
+        };
+        yield runError;
+      }
+    })();
+  }
+
+  /**
    * Validate that required external tools are registered before invoking.
    */
   public validateExternalTools(tools: DistriBaseTool[] = []): ExternalToolValidationResult {

--- a/packages/core/src/distri-client.ts
+++ b/packages/core/src/distri-client.ts
@@ -865,6 +865,29 @@ export class DistriClient {
   }
 
   /**
+   * Resubscribe to an existing task's event stream. Used when
+   * reopening a thread whose task is still running in the background
+   * on the server (see `Thread.active_task_id`). Yields only events
+   * emitted from the subscribe point forward — historical events must
+   * be loaded separately via thread messages.
+   *
+   * The server handles the terminal-state race: if the task finishes
+   * between the client's `getThread` and this subscribe, the server
+   * synthesizes a final TaskStatusUpdate so the stream still yields
+   * the end state.
+   */
+  async * resubscribeTask(agentId: string, taskId: string): AsyncGenerator<A2AStreamEventData> {
+    try {
+      const client = this.getA2AClient(agentId);
+      yield* await client.resubscribeTask({ id: taskId });
+    } catch (error) {
+      console.error(error);
+      const errorMessage = this.extractErrorMessage(error);
+      throw new DistriError(errorMessage, 'RESUBSCRIBE_TASK_ERROR', error);
+    }
+  }
+
+  /**
    * Extract a user-friendly error message from potentially nested errors
    */
   private extractErrorMessage(error: unknown): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -765,6 +765,13 @@ export interface DistriThread {
   input_tokens?: number;
   output_tokens?: number;
   total_tokens?: number;
+  /**
+   * ID of a task currently running in this thread, if any. Populated
+   * by the server on single-thread GET from non-terminal tasks. When
+   * present, the client should call `agent.resubscribeStream(taskId)`
+   * to reattach to the in-flight task's event stream.
+   */
+  active_task_id?: string;
 }
 
 export interface Thread {
@@ -782,6 +789,13 @@ export interface Thread {
   input_tokens?: number;
   output_tokens?: number;
   total_tokens?: number;
+  /**
+   * ID of a task currently running in this thread, if any. Populated
+   * by the server on single-thread GET from non-terminal tasks in the
+   * task store. Clients use this to decide whether to call
+   * `resubscribeTask` when reopening a conversation.
+   */
+  active_task_id?: string;
 }
 
 /**

--- a/packages/react/src/useChat.ts
+++ b/packages/react/src/useChat.ts
@@ -156,6 +156,28 @@ export function useChat({
       processMessage(event, true);
     }, [processMessage]);
 
+  /**
+   * Consume an async stream of chat events, honoring the abort
+   * signal and forwarding events through `handleStreamEvent`.
+   * Shared between `sendMessage`, `sendMessageStream`, and the
+   * thread-reattach effect so all three paths get identical
+   * event-handling, abort, and cleanup behavior. Returns the number
+   * of events processed — callers use this to detect the
+   * terminal-race fallback case.
+   */
+  const consumeStream = useCallback(
+    async (stream: AsyncGenerator<DistriChatMessage>) => {
+      let count = 0;
+      for await (const event of stream) {
+        if (abortControllerRef.current?.signal.aborted) break;
+        handleStreamEvent(event);
+        count++;
+      }
+      return count;
+    },
+    [handleStreamEvent],
+  );
+
   const sendMessage = useCallback(async (content: string | DistriPart[]) => {
     if (!agent) return;
 
@@ -201,12 +223,7 @@ export function useChat({
         },
       }, externalTools);
 
-      for await (const event of stream) {
-        if (abortControllerRef.current?.signal.aborted) {
-          break;
-        }
-        handleStreamEvent(event);
-      }
+      await consumeStream(stream);
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         // Stream was cancelled, don't show error
@@ -233,7 +250,7 @@ export function useChat({
       setStreaming(false);
       abortControllerRef.current = null;
     }
-  }, [agent, beforeSendMessage, createInvokeContext, currentTaskId, externalTools, handleStreamEvent, processMessage, setError, setLoading, setStreaming, setStreamingIndicator, failAllPendingToolCalls]);
+  }, [agent, beforeSendMessage, consumeStream, createInvokeContext, currentTaskId, externalTools, processMessage, setError, setLoading, setStreaming, setStreamingIndicator, failAllPendingToolCalls]);
 
   const sendMessageStream = useCallback(async (content: string | DistriPart[], role: 'user' | 'tool' = 'user') => {
     if (!agent) return;
@@ -276,12 +293,7 @@ export function useChat({
         }
       });
 
-      for await (const event of stream) {
-        if (abortControllerRef.current?.signal.aborted) {
-          break;
-        }
-        handleStreamEvent(event);
-      }
+      await consumeStream(stream);
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         // Stream was cancelled, don't show error
@@ -308,12 +320,29 @@ export function useChat({
       setStreaming(false);
       abortControllerRef.current = null;
     }
-  }, [agent, createInvokeContext, currentTaskId, handleStreamEvent, processMessage, setError, setLoading, setStreaming, setStreamingIndicator, failAllPendingToolCalls]);
+  }, [agent, consumeStream, createInvokeContext, currentTaskId, processMessage, setError, setLoading, setStreaming, setStreamingIndicator, failAllPendingToolCalls]);
 
 
   const stopStreaming = useCallback(() => {
+    // Abort the local stream first so the UI stops immediately even
+    // if the network cancel is slow.
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
+    }
+    // Explicit stop = user wants the task stopped. Fire the backend
+    // `tasks/cancel` so the background execution actually halts
+    // instead of continuing to run on the server. Closing the tab or
+    // losing network does NOT hit this path — those cases rely on the
+    // backend's background-task model keeping execution alive for
+    // later resubscribe.
+    if (agent && currentTaskId) {
+      agent.client
+        .cancelTask(agent.name, currentTaskId)
+        .catch((err: unknown) => {
+          // Idempotent cancel: server returns success for
+          // already-terminal tasks. Log anything else.
+          console.warn('cancelTask failed:', err);
+        });
     }
     // Fail all pending tool calls so they don't complete after cancel
     // and trigger the agent to restart via completeTool retry
@@ -321,7 +350,77 @@ export function useChat({
     setStreamingIndicator(undefined);
     setStreaming(false);
     setLoading(false);
-  }, [failAllPendingToolCalls, setStreamingIndicator, setStreaming, setLoading]);
+  }, [agent, currentTaskId, failAllPendingToolCalls, setStreamingIndicator, setStreaming, setLoading]);
+
+  // Reattach to a background task when reopening a thread. If the
+  // server reports `thread.active_task_id`, call `resubscribeStream`
+  // and feed events through the shared consumeStream helper so the
+  // UI picks up exactly where the previous client left off. If
+  // resubscribe yields no events (the task finished between getThread
+  // and subscribe), fall back to `getTask` to render the final state.
+  useEffect(() => {
+    if (!agent || !threadId) return;
+    const abort = new AbortController();
+
+    (async () => {
+      try {
+        const thread = await agent.client.getThread(threadId);
+        if (abort.signal.aborted) return;
+        const activeTaskId = thread?.active_task_id;
+        if (!activeTaskId) return;
+
+        // Stake ownership of the stream state so `stopStreaming` and
+        // the existing abort logic behave identically for resumed
+        // tasks.
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort();
+        }
+        abortControllerRef.current = new AbortController();
+        setStreaming(true);
+        setLoading(true);
+        setStreamingIndicator('typing');
+
+        const stream = await agent.resubscribeStream(activeTaskId);
+        const eventCount = await consumeStream(stream);
+
+        if (eventCount === 0) {
+          // Terminal race: task finished between getThread and
+          // resubscribe. Fetch final task state and synthesize a
+          // run_finished-style update through processMessage so the
+          // UI reflects the outcome.
+          try {
+            const task = await agent.client.getTask(agent.name, activeTaskId);
+            handleStreamEvent({
+              type: 'run_finished',
+              data: { task_id: activeTaskId, status: task?.status },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any);
+          } catch (err) {
+            console.warn('getTask fallback failed:', err);
+          }
+        }
+      } catch (err) {
+        if (!abort.signal.aborted) {
+          console.warn('Resubscribe on thread open failed:', err);
+        }
+      } finally {
+        if (!abort.signal.aborted) {
+          setStreamingIndicator(undefined);
+          setStreaming(false);
+          setLoading(false);
+          abortControllerRef.current = null;
+        }
+      }
+    })();
+
+    return () => {
+      abort.abort();
+    };
+    // threadId + agent identity drive reattach; consumeStream and
+    // handleStreamEvent are stable across renders once their inputs
+    // settle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, threadId]);
 
   return {
     isStreaming,


### PR DESCRIPTION
## Summary
This PR adds support for reattaching to background tasks when reopening a thread. When a user closes and reopens a conversation, the client can now detect if a task is still running on the server and resume streaming its events, providing a seamless experience without losing progress.

## Key Changes

- **Extract shared stream consumption logic**: Created a new `consumeStream` helper in `useChat` that centralizes event handling, abort signal checking, and cleanup. This ensures consistent behavior across `sendMessage`, `sendMessageStream`, and the new thread-reattach effect.

- **Add thread reattachment effect**: Implemented a new `useEffect` in `useChat` that:
  - Detects active background tasks via `thread.active_task_id` when opening a thread
  - Calls `agent.resubscribeStream()` to reattach to the in-flight task
  - Handles the terminal-race case where a task finishes between `getThread` and `resubscribe` by falling back to `getTask`
  - Properly manages abort signals and streaming state

- **Implement resubscribe methods**: 
  - Added `resubscribeStream()` to `Agent` class to reattach to an existing task's event stream
  - Added `resubscribeTask()` to `DistriClient` to handle the low-level API call
  - Both methods decode events identically to `invokeStream` for consistency

- **Enhance stopStreaming**: Updated `stopStreaming` to explicitly cancel the backend task via `agent.client.cancelTask()`, ensuring the server halts execution rather than continuing in the background.

- **Update type definitions**: Added `active_task_id` field to both `DistriThread` and `Thread` interfaces to communicate active background tasks from server to client.

## Implementation Details

- The `consumeStream` helper returns an event count, allowing callers to detect the terminal-race fallback case
- Reattachment uses the same abort controller and state management as regular message sending
- The effect properly cleans up abort signals and only triggers on `agent` and `threadId` changes
- Error handling includes graceful degradation for network failures and already-terminal tasks

https://claude.ai/code/session_01Mrkyw83gbu8T6nTurVfmix