### PR TITLE
feat(core): add FilePart and route file/image by MIME

### DIFF
--- a/packages/core/src/__tests__/encoder-file-part.test.ts
+++ b/packages/core/src/__tests__/encoder-file-part.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { convertA2APartToDistri, convertDistriPartToA2A } from '../encoder';
+import type { Part as A2APart } from '@a2a-js/sdk';
+
+describe('encoder file-part MIME routing', () => {
+  it('routes A2A pdf file → distri part_type:file', () => {
+    const a2a: A2APart = {
+      kind: 'file',
+      file: {
+        bytes: 'JVBERi0xLjQK',
+        mimeType: 'application/pdf',
+        name: 'r.pdf',
+      },
+    };
+    const distri = convertA2APartToDistri(a2a);
+    expect(distri.part_type).toBe('file');
+    expect(distri.data).toMatchObject({
+      type: 'bytes',
+      mime_type: 'application/pdf',
+      bytes: 'JVBERi0xLjQK',
+    });
+  });
+
+  it('routes A2A image file → distri part_type:image (unchanged)', () => {
+    const a2a: A2APart = {
+      kind: 'file',
+      file: {
+        uri: 'https://example.com/cat.png',
+        mimeType: 'image/png',
+      },
+    };
+    const distri = convertA2APartToDistri(a2a);
+    expect(distri.part_type).toBe('image');
+  });
+
+  it('routes A2A unknown-mime file → distri part_type:file', () => {
+    const a2a: A2APart = {
+      kind: 'file',
+      file: { bytes: 'AAA', mimeType: 'application/octet-stream' },
+    };
+    expect(convertA2APartToDistri(a2a).part_type).toBe('file');
+  });
+
+  it('round-trips distri file → A2A file', () => {
+    const distri = {
+      part_type: 'file' as const,
+      data: { type: 'url' as const, mime_type: 'application/pdf', url: 'https://e.com/d.pdf' },
+    };
+    const a2a = convertDistriPartToA2A(distri);
+    expect(a2a.kind).toBe('file');
+    expect((a2a as any).file).toMatchObject({
+      uri: 'https://e.com/d.pdf',
+      mimeType: 'application/pdf',
+    });
+  });
+});

--- a/packages/core/src/encoder.ts
+++ b/packages/core/src/encoder.ts
@@ -336,15 +336,27 @@ export function convertA2APartToDistri(a2aPart: Part): DistriPart {
   switch (a2aPart.kind) {
     case 'text':
       return { part_type: 'text', data: a2aPart.text };
-    case 'file':
+    case 'file': {
+      const mime = a2aPart.file.mimeType ?? 'application/octet-stream';
+      const partType: 'image' | 'file' = mime.startsWith('image/') ? 'image' : 'file';
       if ('uri' in a2aPart.file) {
-        const fileUrl: FileUrl = { type: 'url', mime_type: a2aPart.file.mimeType || 'application/octet-stream', url: a2aPart.file.uri || '' };
-        return { part_type: 'image', data: fileUrl };
+        const fileUrl: FileUrl = {
+          type: 'url',
+          mime_type: mime,
+          url: a2aPart.file.uri,
+          name: a2aPart.file.name,
+        };
+        return { part_type: partType, data: fileUrl } as DistriPart;
+      } else {
+        const fileBytes: FileBytes = {
+          type: 'bytes',
+          mime_type: mime,
+          bytes: a2aPart.file.bytes ?? '',
+          name: a2aPart.file.name,
+        };
+        return { part_type: partType, data: fileBytes } as DistriPart;
       }
-      else {
-        const fileBytes: FileBytes = { type: 'bytes', mime_type: a2aPart.file.mimeType || 'application/octet-stream', bytes: a2aPart.file.bytes || '' };
-        return { part_type: 'image', data: fileBytes };
-      }
+    }
     case 'data':
       switch (a2aPart.data.part_type) {
         case 'tool_call':
@@ -406,6 +418,7 @@ export function convertDistriPartToA2A(distriPart: DistriPart): Part {
       result = { kind: 'text', text: distriPart.data };
       break;
     case 'image':
+    case 'file':
       if ('url' in distriPart.data) {
         const fileUri: FileWithUri = { mimeType: distriPart.data.mime_type, uri: distriPart.data.url };
         result = { kind: 'file', file: fileUri };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -354,6 +354,7 @@ export type TextPart = { part_type: 'text'; data: string }
 export type ToolCallPart = { part_type: 'tool_call'; data: ToolCall }
 export type ToolResultRefPart = { part_type: 'tool_result'; data: ToolResult }
 export type ImagePart = { part_type: 'image'; data: FileType }
+export type FilePart = { part_type: 'file'; data: FileType }
 export type DataPart = { part_type: 'data'; data: object }
 export type ArtifactPart = { part_type: 'artifact'; data: {
   file_id?: string;
@@ -362,7 +363,14 @@ export type ArtifactPart = { part_type: 'artifact'; data: {
   original_filename?: string;
   size?: number;
 } }
-export type DistriPart = TextPart | ToolCallPart | ToolResultRefPart | ImagePart | DataPart | ArtifactPart;
+export type DistriPart =
+  | TextPart
+  | ToolCallPart
+  | ToolResultRefPart
+  | ImagePart
+  | FilePart
+  | DataPart
+  | ArtifactPart;
 
 
 


### PR DESCRIPTION
Adds part_type: 'file' to the DistriPart union so non-image documents flow through distrijs without being silently coerced into image parts. A2A → Distri conversion now routes by MIME (image/* → image, else → file) and Distri → A2A handles 'file' identically to 'image' since A2A uses a single file kind on the wire.