### PR TITLE
Add exec_js tool for running JavaScript in browser with db access

### DIFF
--- a/packages/react/src/__tests__/exec.test.ts
+++ b/packages/react/src/__tests__/exec.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createExecJsHandler,
+  createExecJsTool,
+  EXEC_JS_TOOL_DEF,
+} from '../browser-tools/tools/exec'
+import { IndexedDbStore } from '../browser-tools/storage/indexeddb-store'
+import type { CollectionDef } from '../browser-tools/tools/shared'
+
+interface ExecResult {
+  stdout: string
+  stderr: string
+  exit_code: number
+  duration_ms: number
+}
+
+let suiteId = 0
+function uniqueName(base: string) {
+  suiteId += 1
+  return `${base}-${Date.now().toString(36)}-${suiteId}`
+}
+
+function makeFixture(extraCollections: CollectionDef[] = []) {
+  const itemsName = uniqueName('items')
+  const tagsName = uniqueName('tags')
+  const collections: CollectionDef[] = [
+    { name: itemsName, description: 'Test items' },
+    { name: tagsName, description: 'Test tags' },
+    ...extraCollections,
+  ]
+  const stores: Record<string, IndexedDbStore> = {}
+  for (const c of collections) {
+    stores[c.name] = IndexedDbStore.forName(c.name)
+  }
+  return { collections, stores, itemsName, tagsName }
+}
+
+async function runExec(
+  fixture: ReturnType<typeof makeFixture>,
+  code: string,
+  opts: { timeout?: number; onChange?: (e: unknown) => void } = {},
+): Promise<ExecResult> {
+  const handler = createExecJsHandler({
+    stores: fixture.stores,
+    collections: fixture.collections,
+    onChange: opts.onChange as never,
+  })
+  const parts = await handler({ code, timeout: opts.timeout })
+  return (parts[0] as { data: ExecResult }).data
+}
+
+describe('exec_js tool', () => {
+  describe('tool definition', () => {
+    it('exposes a stable name + schema', () => {
+      expect(EXEC_JS_TOOL_DEF.name).toBe('exec_js')
+      expect(EXEC_JS_TOOL_DEF.parameters.required).toEqual(['code'])
+      expect(EXEC_JS_TOOL_DEF.parameters.properties.code.type).toBe('string')
+      expect(EXEC_JS_TOOL_DEF.parameters.properties.timeout.type).toBe('number')
+    })
+
+    it('createExecJsTool wraps the handler with FN_BASE flags', () => {
+      const fx = makeFixture()
+      const tool = createExecJsTool({
+        stores: fx.stores,
+        collections: fx.collections,
+      })
+      expect(tool.name).toBe('exec_js')
+      expect(tool.type).toBe('function')
+      expect(tool.isExternal).toBe(true)
+      expect(tool.autoExecute).toBe(true)
+      expect(typeof tool.handler).toBe('function')
+    })
+  })
+
+  describe('basic execution', () => {
+    it('captures console.log to stdout', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `console.log('hello', 'world')`)
+      expect(r.stdout).toBe('hello world')
+      expect(r.stderr).toBe('')
+      expect(r.exit_code).toBe(0)
+    })
+
+    it('captures console.error / console.warn to stderr', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `console.error('boom'); console.warn('careful')`,
+      )
+      expect(r.stdout).toBe('')
+      expect(r.stderr.split('\n')).toEqual(['boom', 'careful'])
+      expect(r.exit_code).toBe(0)
+    })
+
+    it('uses the return value when nothing was logged', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `return 1 + 2`)
+      expect(r.stdout).toBe('3')
+      expect(r.exit_code).toBe(0)
+    })
+
+    it('does not stomp logged output with the return value', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `console.log('logged'); return 'ignored-because-stdout-set'`,
+      )
+      expect(r.stdout).toBe('logged')
+    })
+
+    it('JSON-stringifies object args to console.log', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `console.log({ a: 1, b: [2, 3] })`)
+      expect(r.stdout).toBe('{"a":1,"b":[2,3]}')
+    })
+
+    it('captures thrown errors as stderr + exit_code 1', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `throw new Error('nope')`)
+      expect(r.stderr).toBe('nope')
+      expect(r.exit_code).toBe(1)
+    })
+
+    it('reports duration_ms as a non-negative number', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `return 'x'`)
+      expect(typeof r.duration_ms).toBe('number')
+      expect(r.duration_ms).toBeGreaterThanOrEqual(0)
+    })
+
+    it('supports await inside the script', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await new Promise(r => setTimeout(r, 5)); return 'done'`,
+      )
+      expect(r.stdout).toBe('done')
+      expect(r.exit_code).toBe(0)
+    })
+  })
+
+  describe('timeout', () => {
+    it('times out long-running scripts with exit_code 1', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await new Promise(r => setTimeout(r, 200))`,
+        { timeout: 20 },
+      )
+      expect(r.exit_code).toBe(1)
+      expect(r.stderr).toMatch(/timed out after 20ms/)
+    })
+
+    it('clamps timeout to the 30s ceiling', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `return 'ok'`, { timeout: 999_999 })
+      expect(r.stdout).toBe('ok')
+    })
+  })
+
+  describe('db API surface', () => {
+    it('exposes db.collections() with name/description (no store leak)', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `return JSON.stringify(db.collections())`)
+      const cols = JSON.parse(r.stdout)
+      expect(cols).toHaveLength(2)
+      expect(cols[0].name).toBe(fx.itemsName)
+      expect(cols[0].description).toBe('Test items')
+      expect(cols[0]).not.toHaveProperty('store')
+    })
+
+    it('db.put inserts a record and returns the recordView shape', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `const rec = await db.put(${JSON.stringify(fx.itemsName)}, { data: { title: 'First' } });
+         return JSON.stringify({ hasId: typeof rec.id === 'string', title: rec.title, hasMeta: !!rec._meta });`,
+      )
+      expect(r.exit_code).toBe(0)
+      expect(JSON.parse(r.stdout)).toEqual({
+        hasId: true,
+        title: 'First',
+        hasMeta: true,
+      })
+    })
+
+    it('db.get round-trips a record put via the same API', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `const a = await db.put(${JSON.stringify(fx.itemsName)}, { id: 'x1', data: { title: 'A' } });
+         const b = await db.get(${JSON.stringify(fx.itemsName)}, 'x1');
+         return JSON.stringify({ a_id: a.id, b_id: b.id, title: b.title });`,
+      )
+      expect(JSON.parse(r.stdout)).toEqual({ a_id: 'x1', b_id: 'x1', title: 'A' })
+    })
+
+    it('db.get returns null for missing ids', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `return await db.get(${JSON.stringify(fx.itemsName)}, 'does-not-exist')`,
+      )
+      expect(r.stdout).toBe('null')
+    })
+
+    it('db.list returns every record sorted by createdAt', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'a', data: { n: 1 } });
+         await db.put(${JSON.stringify(fx.itemsName)}, { id: 'b', data: { n: 2 } });
+         const all = await db.list(${JSON.stringify(fx.itemsName)});
+         return JSON.stringify(all.map(r => ({ id: r.id, n: r.n })));`,
+      )
+      expect(JSON.parse(r.stdout)).toEqual([
+        { id: 'a', n: 1 },
+        { id: 'b', n: 2 },
+      ])
+    })
+
+    it('db.search filters by case-insensitive substring of data', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: '1', data: { title: 'Celebration day' } });
+         await db.put(${JSON.stringify(fx.itemsName)}, { id: '2', data: { title: 'Boring meeting' } });
+         await db.put(${JSON.stringify(fx.itemsName)}, { id: '3', data: { title: 'A celebration' } });
+         const hits = await db.search(${JSON.stringify(fx.itemsName)}, 'CELEBRATION');
+         return JSON.stringify(hits.map(h => h.id).sort());`,
+      )
+      expect(JSON.parse(r.stdout)).toEqual(['1', '3'])
+    })
+
+    it('db.search with empty query returns everything', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: '1', data: { x: 1 } });
+         await db.put(${JSON.stringify(fx.itemsName)}, { id: '2', data: { x: 2 } });
+         const hits = await db.search(${JSON.stringify(fx.itemsName)}, '');
+         return hits.length;`,
+      )
+      expect(r.stdout).toBe('2')
+    })
+
+    it('db.delete removes a record', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'd', data: { x: 1 } });
+         await db.delete(${JSON.stringify(fx.itemsName)}, 'd');
+         const after = await db.get(${JSON.stringify(fx.itemsName)}, 'd');
+         return after === null ? 'gone' : 'still-there';`,
+      )
+      expect(r.stdout).toBe('gone')
+    })
+
+    it('db.clear wipes the collection', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'a', data: { x: 1 } });
+         await db.put(${JSON.stringify(fx.itemsName)}, { id: 'b', data: { x: 2 } });
+         await db.clear(${JSON.stringify(fx.itemsName)});
+         return (await db.list(${JSON.stringify(fx.itemsName)})).length;`,
+      )
+      expect(r.stdout).toBe('0')
+    })
+
+    it('rejects unknown collection names with a helpful error', async () => {
+      const fx = makeFixture()
+      const r = await runExec(fx, `await db.list('nope-not-registered')`)
+      expect(r.exit_code).toBe(1)
+      expect(r.stderr).toMatch(/Unknown collection "nope-not-registered"/)
+      expect(r.stderr).toMatch(new RegExp(fx.itemsName))
+    })
+
+    it('isolates collections from each other', async () => {
+      const fx = makeFixture()
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'shared', data: { from: 'items' } });
+         const fromTags = await db.get(${JSON.stringify(fx.tagsName)}, 'shared');
+         return fromTags === null ? 'isolated' : 'leaked';`,
+      )
+      expect(r.stdout).toBe('isolated')
+    })
+  })
+
+  describe('change notifications', () => {
+    it('fires onChange for put / delete / clear via exec', async () => {
+      const fx = makeFixture()
+      const events: Array<{ store: string; op: string; id?: string }> = []
+      const r = await runExec(
+        fx,
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'p1', data: { x: 1 } });
+         await db.delete(${JSON.stringify(fx.itemsName)}, 'p1');
+         await db.clear(${JSON.stringify(fx.itemsName)});
+         return 'ok';`,
+        { onChange: (e) => events.push(e as never) },
+      )
+      expect(r.exit_code).toBe(0)
+      expect(events).toEqual([
+        { store: fx.itemsName, op: 'put', id: 'p1' },
+        { store: fx.itemsName, op: 'delete', id: 'p1' },
+        { store: fx.itemsName, op: 'clear' },
+      ])
+    })
+  })
+
+  describe('aggregation pattern (the reason this tool exists)', () => {
+    it('reduces across many records in a single tool call', async () => {
+      const fx = makeFixture()
+      const setup = Array.from({ length: 25 }, (_, i) =>
+        `await db.put(${JSON.stringify(fx.itemsName)}, { id: 'r${i}', data: { word_count: ${i + 1} } });`,
+      ).join('\n')
+      const r = await runExec(
+        fx,
+        `${setup}
+         const all = await db.list(${JSON.stringify(fx.itemsName)});
+         const total = all.reduce((n, r) => n + r.word_count, 0);
+         return JSON.stringify({ count: all.length, total });`,
+      )
+      expect(JSON.parse(r.stdout)).toEqual({ count: 25, total: 325 })
+    })
+  })
+})

--- a/packages/react/src/browser-tools/index.ts
+++ b/packages/react/src/browser-tools/index.ts
@@ -11,6 +11,7 @@ export {
   DB_DELETE_TOOL_DEF,
   DB_CLEAR_TOOL_DEF,
   DB_COLLECTIONS_TOOL_DEF,
+  EXEC_JS_TOOL_DEF,
   createDbPutHandler,
   createDbGetHandler,
   createDbListHandler,
@@ -18,6 +19,7 @@ export {
   createDbDeleteHandler,
   createDbClearHandler,
   createDbCollectionsHandler,
+  createExecJsHandler,
   createDbPutTool,
   createDbGetTool,
   createDbListTool,
@@ -25,5 +27,13 @@ export {
   createDbDeleteTool,
   createDbClearTool,
   createDbCollectionsTool,
+  createExecJsTool,
 } from './tools'
-export type { CollectionDef, CreateDbToolsOptions, CreateDbToolsResult } from './tools'
+export type {
+  CollectionDef,
+  CreateDbToolsOptions,
+  CreateDbToolsResult,
+  ExecJsParams,
+  ExecDbApi,
+  CreateExecJsHandlerOptions,
+} from './tools'

--- a/packages/react/src/browser-tools/tools/exec.ts
+++ b/packages/react/src/browser-tools/tools/exec.ts
@@ -1,0 +1,196 @@
+/**
+ * `exec_js` — run unsafe JavaScript in the browser host with direct access to
+ * the agent's IndexedDB collections via a `db` global.
+ *
+ * This is the escape hatch for cases where the granular `db_*` tools would
+ * require dozens of round-trips: the agent writes a small script that loads
+ * records, reshapes them, and emits the answer in one tool call. The script
+ * runs inside `new Function(...)`, so it can do anything page-script JS can —
+ * including hitting `fetch`, `crypto`, etc. Treat the host as the trust
+ * boundary.
+ *
+ * The `db` object surface intentionally mirrors the `db_*` tool set so the
+ * agent doesn't have to learn a second API:
+ *
+ *   db.collections()                       -> CollectionDef[]
+ *   db.list(collection)                    -> Array<record>
+ *   db.get(collection, id)                 -> record | null
+ *   db.search(collection, query)           -> Array<record>
+ *   db.put(collection, { id?, data })      -> record
+ *   db.delete(collection, id)              -> void
+ *   db.clear(collection)                   -> void
+ *
+ * Each `record` returned has the same shape the `db_*` tools emit:
+ * `{ id, ...data, _meta: { createdAt, updatedAt } }`.
+ */
+
+import type { DistriFnTool } from '@distri/core'
+import type { IndexedDbStore, StoreChangeEvent } from '../storage/indexeddb-store'
+import type { CollectionDef, OnChange } from './shared'
+import { FN_BASE, makeResolver, recordView } from './shared'
+
+export interface ExecJsParams {
+  code: string
+  timeout?: number
+}
+
+export const EXEC_JS_TOOL_DEF = {
+  name: 'exec_js',
+  description:
+    'Execute unsafe JavaScript code in the browser sandbox with access to the agent\'s IndexedDB collections via a `db` global.',
+  prompt:
+    'Runs JavaScript directly in the browser host. Use this when assembling an answer from many records would otherwise need dozens of `db_*` calls.\n' +
+    '- The code runs as an async function. `return` a value or use `console.log()` — both go to stdout.\n' +
+    '- A `db` global is injected with methods that mirror the db_* tools:\n' +
+    '    db.collections() -> Array<{ name, description, schema? }>\n' +
+    '    db.list(collection) -> Array<record>\n' +
+    '    db.get(collection, id) -> record | null\n' +
+    '    db.search(collection, query) -> Array<record>\n' +
+    '    db.put(collection, { id?, data }) -> record\n' +
+    '    db.delete(collection, id) -> void\n' +
+    '    db.clear(collection) -> void\n' +
+    '  Each record has shape `{ id, ...data, _meta: { createdAt, updatedAt } }`.\n' +
+    '- All db.* methods return Promises — use `await`.\n' +
+    '- Default timeout is 5000ms, max 30000ms.\n' +
+    '- This is browser JS, not Node — no `require`, `process`, or fs.',
+  parameters: {
+    type: 'object',
+    required: ['code'],
+    properties: {
+      code: { type: 'string', description: 'JavaScript code to execute. Use `await` for db calls; `return` or `console.log()` for output.' },
+      timeout: { type: 'number', description: 'Timeout in milliseconds (default 5000, max 30000).' },
+    },
+  },
+} as const
+
+export interface ExecDbApi {
+  collections: () => CollectionDef[]
+  list: (collection: string) => Promise<Array<Record<string, unknown>>>
+  get: (collection: string, id: string) => Promise<Record<string, unknown> | null>
+  search: (collection: string, query: string) => Promise<Array<Record<string, unknown>>>
+  put: (collection: string, args: { id?: string; data: Record<string, unknown> }) => Promise<Record<string, unknown>>
+  delete: (collection: string, id: string) => Promise<void>
+  clear: (collection: string) => Promise<void>
+}
+
+function buildDbApi(
+  stores: Record<string, IndexedDbStore>,
+  collections: CollectionDef[],
+  onChange?: OnChange,
+): ExecDbApi {
+  const resolve = makeResolver(stores)
+  const notify = (event: StoreChangeEvent) => {
+    if (onChange) onChange(event)
+  }
+  return {
+    collections: () => collections.map((c) => ({ name: c.name, description: c.description, schema: c.schema })),
+    list: async (collection) => {
+      const records = await resolve(collection).list()
+      return records.map((r) => recordView(r) as Record<string, unknown>)
+    },
+    get: async (collection, id) => {
+      const r = await resolve(collection).get(id)
+      return r ? (recordView(r) as Record<string, unknown>) : null
+    },
+    search: async (collection, query) => {
+      const q = String(query ?? '').toLowerCase()
+      const records = await resolve(collection).list()
+      const matches = q
+        ? records.filter((r) => JSON.stringify(r.data).toLowerCase().includes(q))
+        : records
+      return matches.map((r) => recordView(r) as Record<string, unknown>)
+    },
+    put: async (collection, args) => {
+      const store = resolve(collection)
+      const record = await store.put({ id: args?.id, data: args?.data ?? {} })
+      notify({ store: collection, op: 'put', id: record.id })
+      return recordView(record) as Record<string, unknown>
+    },
+    delete: async (collection, id) => {
+      await resolve(collection).delete(id)
+      notify({ store: collection, op: 'delete', id })
+    },
+    clear: async (collection) => {
+      await resolve(collection).clear()
+      notify({ store: collection, op: 'clear' })
+    },
+  }
+}
+
+export interface CreateExecJsHandlerOptions {
+  stores: Record<string, IndexedDbStore>
+  collections: CollectionDef[]
+  onChange?: OnChange
+}
+
+export function createExecJsHandler(options: CreateExecJsHandlerOptions) {
+  const db = buildDbApi(options.stores, options.collections, options.onChange)
+  return async (input: unknown) => {
+    const params = (input ?? {}) as ExecJsParams
+    const timeoutMs = Math.min(Math.max(params.timeout ?? 5000, 1), 30000)
+    const startTime = Date.now()
+
+    let stdout = ''
+    let stderr = ''
+    let exitCode = 0
+
+    const consoleMock = {
+      log: (...args: unknown[]) => { stdout += args.map(stringifyArg).join(' ') + '\n' },
+      error: (...args: unknown[]) => { stderr += args.map(stringifyArg).join(' ') + '\n' },
+      warn: (...args: unknown[]) => { stderr += args.map(stringifyArg).join(' ') + '\n' },
+      info: (...args: unknown[]) => { stdout += args.map(stringifyArg).join(' ') + '\n' },
+    }
+
+    try {
+      const fn = new Function('console', 'db', `
+        return (async () => {
+          ${params.code}
+        })()
+      `)
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const result = await Promise.race([
+        fn(consoleMock, db),
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Execution timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+          )
+        }),
+      ])
+      if (timer) clearTimeout(timer)
+
+      if (result !== undefined && !stdout) {
+        stdout = stringifyArg(result) + '\n'
+      }
+    } catch (err) {
+      stderr += (err instanceof Error ? err.message : String(err)) + '\n'
+      exitCode = 1
+    }
+
+    const durationMs = Date.now() - startTime
+    return [{
+      part_type: 'data' as const,
+      data: {
+        stdout: stdout.trimEnd(),
+        stderr: stderr.trimEnd(),
+        exit_code: exitCode,
+        duration_ms: durationMs,
+      },
+    }]
+  }
+}
+
+export function createExecJsTool(options: CreateExecJsHandlerOptions): DistriFnTool {
+  return { ...FN_BASE, ...EXEC_JS_TOOL_DEF, handler: createExecJsHandler(options) }
+}
+
+function stringifyArg(v: unknown): string {
+  if (typeof v === 'string') return v
+  if (v instanceof Error) return v.message
+  try {
+    return JSON.stringify(v)
+  } catch {
+    return String(v)
+  }
+}

--- a/packages/react/src/browser-tools/tools/index.ts
+++ b/packages/react/src/browser-tools/tools/index.ts
@@ -22,11 +22,18 @@ import { createDbSearchTool } from './db-search'
 import { createDbDeleteTool } from './db-delete'
 import { createDbClearTool } from './db-clear'
 import { createDbCollectionsTool } from './db-collections'
+import { createExecJsTool } from './exec'
 
 export interface CreateDbToolsOptions {
   collections: CollectionDef[]
   /** Notified after every mutation; usually re-dispatched as a window event. */
   onChange?: (event: StoreChangeEvent) => void
+  /**
+   * Include the unsafe `exec_js` tool that runs JavaScript in the browser
+   * with a `db` global wired to these collections. Off by default — only
+   * register on hosts that are happy with arbitrary JS execution.
+   */
+  enableExecJs?: boolean
 }
 
 export interface CreateDbToolsResult {
@@ -50,6 +57,10 @@ export function createDbTools(options: CreateDbToolsOptions): CreateDbToolsResul
     createDbDeleteTool(stores, onChange),
     createDbClearTool(stores, onChange),
   ]
+
+  if (options.enableExecJs) {
+    tools.push(createExecJsTool({ stores, collections: options.collections, onChange }))
+  }
 
   return { tools, stores }
 }
@@ -76,3 +87,5 @@ export { DB_SEARCH_TOOL_DEF, createDbSearchHandler, createDbSearchTool } from '.
 export { DB_DELETE_TOOL_DEF, createDbDeleteHandler, createDbDeleteTool } from './db-delete'
 export { DB_CLEAR_TOOL_DEF, createDbClearHandler, createDbClearTool } from './db-clear'
 export { DB_COLLECTIONS_TOOL_DEF, createDbCollectionsHandler, createDbCollectionsTool } from './db-collections'
+export { EXEC_JS_TOOL_DEF, createExecJsHandler, createExecJsTool } from './exec'
+export type { ExecJsParams, ExecDbApi, CreateExecJsHandlerOptions } from './exec'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -54,6 +54,7 @@ export {
   DB_DELETE_TOOL_DEF,
   DB_CLEAR_TOOL_DEF,
   DB_COLLECTIONS_TOOL_DEF,
+  EXEC_JS_TOOL_DEF,
   createDbPutHandler,
   createDbGetHandler,
   createDbListHandler,
@@ -61,6 +62,7 @@ export {
   createDbDeleteHandler,
   createDbClearHandler,
   createDbCollectionsHandler,
+  createExecJsHandler,
   createDbPutTool,
   createDbGetTool,
   createDbListTool,
@@ -68,6 +70,7 @@ export {
   createDbDeleteTool,
   createDbClearTool,
   createDbCollectionsTool,
+  createExecJsTool,
 } from './browser-tools';
 export type {
   StoreRecord,
@@ -76,6 +79,9 @@ export type {
   CollectionDef,
   CreateDbToolsOptions,
   CreateDbToolsResult,
+  ExecJsParams,
+  ExecDbApi,
+  CreateExecJsHandlerOptions,
 } from './browser-tools';
 
 // Workflow


### PR DESCRIPTION
## Summary
Adds a new `exec_js` tool that allows agents to execute arbitrary JavaScript code in the browser with direct access to IndexedDB collections via a `db` global. This serves as an escape hatch for complex data operations that would otherwise require dozens of individual `db_*` tool calls.

## Key Changes
- **New `exec.ts` module**: Implements the `exec_js` tool with:
  - `buildDbApi()`: Creates a `db` object that mirrors the granular `db_*` tool API (collections, list, get, search, put, delete, clear)
  - `createExecJsHandler()`: Executes user code in a sandboxed `Function` context with mocked console and injected `db` global
  - Timeout enforcement (default 5s, max 30s) using `Promise.race()`
  - Proper error handling and output capture (stdout/stderr/exit code)
  - Support for both `return` statements and `console.log()` for output

- **Updated `tools/index.ts`**:
  - Added `enableExecJs` option to `CreateDbToolsOptions` (disabled by default for security)
  - Conditionally registers the `exec_js` tool when enabled
  - Exports new types and handlers

- **Updated exports**: Added `exec_js` tool definitions and types to `browser-tools/index.ts` and root `index.ts`

## Notable Implementation Details
- The `db` API intentionally mirrors the `db_*` tool set so agents don't need to learn a second API
- Records returned have the same shape as `db_*` tools: `{ id, ...data, _meta: { createdAt, updatedAt } }`
- All `db.*` methods are async and return Promises (agents must use `await`)
- Code runs as an async IIFE within `new Function()`, allowing access to browser APIs like `fetch` and `crypto`
- The tool is opt-in via `enableExecJs` flag to ensure hosts explicitly consent to arbitrary JS execution
- Comprehensive prompt documentation explains usage, limitations, and the `db` API surface

https://claude.ai/code/session_01Aq7GjAXnWBEFasZFjRR3i1