### PR TITLE
Claude/mcp server integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/workspace",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "packageManager": "pnpm@10.11.1",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/core",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Core API client for Distri Framework",
   "exports": {
     ".": {

--- a/packages/core/src/encoder.ts
+++ b/packages/core/src/encoder.ts
@@ -472,6 +472,24 @@ export function convertDistriPartToA2A(distriPart: DistriPart): Part {
       };
       break;
     }
+    case 'resource_link': {
+      // MCP-Apps resource reference. Same envelope convention as artifact /
+      // tool_call — wrap in A2A DataPart with `part_type` discriminator so
+      // the Rust side deserializes back to Part::ResourceLink via the
+      // `#[serde(tag = "part_type", content = "data")]` Part enum.
+      result = {
+        kind: 'data',
+        data: {
+          part_type: 'resource_link',
+          data: distriPart.data
+        }
+      };
+      break;
+    }
+    default: {
+      const _exhaustive: never = distriPart;
+      throw new Error(`Unhandled DistriPart variant: ${JSON.stringify(_exhaustive)}`);
+    }
   }
   return result;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -370,6 +370,21 @@ export type ArtifactPart = { part_type: 'artifact'; data: {
   original_filename?: string;
   size?: number;
 } }
+/** MCP-Apps resource reference returned by a tool. Hosts that understand
+ * the `_meta.ui.resourceUri` convention render this as a sandboxed iframe;
+ * everyone else falls back to the optional `text` field. Mirrors
+ * `distri_types::ResourceLink` on the Rust side. */
+export type ResourceLinkPart = {
+  part_type: 'resource_link';
+  data: {
+    uri: string;
+    mime_type?: string;
+    text?: string;
+    /** The raw `_meta` object the MCP server attached, e.g.
+     *  `{ ui: { resourceUri, preferredSize } }` */
+    meta?: Record<string, unknown>;
+  };
+}
 export type DistriPart =
   | TextPart
   | ToolCallPart
@@ -377,7 +392,8 @@ export type DistriPart =
   | ImagePart
   | FilePart
   | DataPart
-  | ArtifactPart;
+  | ArtifactPart
+  | ResourceLinkPart;
 
 
 

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/fs",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "IndexedDB-backed filesystem tools and React workspace components for Distri agents",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/react",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "React hooks and components for Distri Framework",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/react/src/components/renderers/MCPAppRenderer.tsx
+++ b/packages/react/src/components/renderers/MCPAppRenderer.tsx
@@ -37,8 +37,6 @@ export interface MCPAppRendererProps {
   fetchResource?: (uri: string) => Promise<string>;
 }
 
-const MCP_UI_MIME = 'text/html;profile=mcp-app';
-
 export function findResourceLinks(result?: { parts: readonly DistriPart[] }): ResourceLinkPart[] {
   if (!result) return [];
   return result.parts.filter(

--- a/packages/react/src/components/renderers/MCPAppRenderer.tsx
+++ b/packages/react/src/components/renderers/MCPAppRenderer.tsx
@@ -84,13 +84,23 @@ interface IframeProps {
 
 const MCPAppIframe: React.FC<IframeProps> = ({ link, toolName, onAction, fetchResource }) => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const [html, setHtml] = useState<string | null>(link.data.text ?? null);
+  // Prefer the direct iframe URL when the server provides one
+  // (`_meta.ui.iframeUrl`) — that's the chromeless page on its own origin
+  // and we can mount it via `src=` without round-tripping resources/read.
+  // Otherwise fall back to inline HTML on `link.data.text`, then to the
+  // optional fetchResource hook for spec-strict hosts.
+  const directUrl = (link.data.meta?.ui as { iframeUrl?: string } | undefined)?.iframeUrl;
+  const [html, setHtml] = useState<string | null>(
+    directUrl ? null : link.data.text ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [height, setHeight] = useState<number>(640);
 
-  // 1. Load resource body. If the server inlined `text`, use it directly;
-  //    otherwise resolve via the optional fetcher.
+  // 1. Load resource body when there's no direct iframe URL. If the server
+  //    inlined `text`, use it directly; otherwise resolve via the optional
+  //    fetcher.
   useEffect(() => {
+    if (directUrl) return;
     if (html != null) return;
     const fetcher = fetchResource;
     if (!fetcher) {
@@ -110,7 +120,7 @@ const MCPAppIframe: React.FC<IframeProps> = ({ link, toolName, onAction, fetchRe
     return () => {
       cancelled = true;
     };
-  }, [link.data.uri, html, fetchResource]);
+  }, [link.data.uri, html, fetchResource, directUrl]);
 
   // 2. Preferred sizing from _meta.ui.preferredSize.
   useEffect(() => {
@@ -162,7 +172,7 @@ const MCPAppIframe: React.FC<IframeProps> = ({ link, toolName, onAction, fetchRe
     );
   }
 
-  if (html == null) {
+  if (!directUrl && html == null) {
     return (
       <div className="my-2 rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
         Loading {toolName}…
@@ -175,7 +185,10 @@ const MCPAppIframe: React.FC<IframeProps> = ({ link, toolName, onAction, fetchRe
       <iframe
         ref={iframeRef}
         title={toolName}
-        srcDoc={html}
+        // Direct URL when the server provides one (single-origin embed —
+        // /embed/new on editor-ui, /embed/learn on the learner ui).
+        // Otherwise fall back to inline HTML via srcDoc.
+        {...(directUrl ? { src: directUrl } : { srcDoc: html ?? '' })}
         sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-modals"
         style={{ width: '100%', height: `${height}px`, border: 0, display: 'block' }}
       />

--- a/packages/react/src/components/renderers/MCPAppRenderer.tsx
+++ b/packages/react/src/components/renderers/MCPAppRenderer.tsx
@@ -1,0 +1,184 @@
+/**
+ * MCPAppRenderer — renders tool results whose payload includes a
+ * `ResourceLinkPart` per the MCP-Apps spec (`_meta.ui.resourceUri`).
+ *
+ * Selected automatically by ToolExecutionRenderer when the tool result
+ * carries at least one resource link with `mime_type` matching
+ * `text/html;profile=mcp-app`. Mounts the resource HTML in a sandboxed
+ * iframe — the same approach the existing `live_view` event uses — and
+ * forwards `mcp-ui:*` postMessage events between iframe and chat:
+ *
+ *   - mcp-ui:tool   → invoke a chat tool (forwarded to onAction)
+ *   - mcp-ui:prompt → send a follow-up prompt as the user
+ *   - mcp-ui:link   → open the URL in a new tab
+ *   - mcp-ui:notify → forwarded to onAction (host can render its own toast)
+ *   - mcp-ui:size   → resize the iframe to fit content
+ *
+ * The renderer fetches the resource body itself rather than letting the
+ * iframe load from the `ui://` URI directly — `ui://` isn't a valid
+ * browser scheme. The fetch goes through the Distri MCP read-resource
+ * endpoint, which mirrors the JSON-RPC `resources/read` call our
+ * upstream `distri-mcp` server already exposes.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ResourceLinkPart, ToolCall, DistriPart } from '@distri/core';
+import type { ToolCallState } from '../../stores/chatStateStore';
+
+export interface MCPAppRendererProps {
+  toolCall: ToolCall;
+  state: ToolCallState;
+  /** Called when the iframe emits mcp-ui:tool or mcp-ui:notify. The host
+   * decides whether to fan the event out (e.g., re-send the prompt to
+   * the agent, surface a toast, etc.). */
+  onAction?: (event: { type: string; payload: unknown }) => void;
+  /** Override how a `ui://` resource is fetched. Defaults to using the
+   * resource's `text` body if the server already inlined it on the
+   * result; otherwise falls back to the configured fetcher. */
+  fetchResource?: (uri: string) => Promise<string>;
+}
+
+const MCP_UI_MIME = 'text/html;profile=mcp-app';
+
+export function findResourceLinks(result?: { parts: readonly DistriPart[] }): ResourceLinkPart[] {
+  if (!result) return [];
+  return result.parts.filter(
+    (p): p is ResourceLinkPart => p.part_type === 'resource_link',
+  );
+}
+
+export function isMcpAppResource(link: ResourceLinkPart): boolean {
+  const mime = link.data.mime_type?.toLowerCase() ?? '';
+  return mime.startsWith('text/html') && mime.includes('mcp-app');
+}
+
+export const MCPAppRenderer: React.FC<MCPAppRendererProps> = ({
+  toolCall,
+  state,
+  onAction,
+  fetchResource,
+}) => {
+  const links = useMemo(() => findResourceLinks(state.result), [state.result]);
+  const primary = links.find(isMcpAppResource) ?? links[0];
+
+  if (!primary) {
+    return null;
+  }
+
+  return (
+    <MCPAppIframe
+      key={primary.data.uri}
+      link={primary}
+      toolName={toolCall.tool_name}
+      onAction={onAction}
+      fetchResource={fetchResource}
+    />
+  );
+};
+
+interface IframeProps {
+  link: ResourceLinkPart;
+  toolName: string;
+  onAction?: (event: { type: string; payload: unknown }) => void;
+  fetchResource?: (uri: string) => Promise<string>;
+}
+
+const MCPAppIframe: React.FC<IframeProps> = ({ link, toolName, onAction, fetchResource }) => {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [html, setHtml] = useState<string | null>(link.data.text ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [height, setHeight] = useState<number>(640);
+
+  // 1. Load resource body. If the server inlined `text`, use it directly;
+  //    otherwise resolve via the optional fetcher.
+  useEffect(() => {
+    if (html != null) return;
+    const fetcher = fetchResource;
+    if (!fetcher) {
+      setError(
+        `Resource ${link.data.uri} has no inline body and no fetchResource configured.`,
+      );
+      return;
+    }
+    let cancelled = false;
+    fetcher(link.data.uri)
+      .then((body) => {
+        if (!cancelled) setHtml(body);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [link.data.uri, html, fetchResource]);
+
+  // 2. Preferred sizing from _meta.ui.preferredSize.
+  useEffect(() => {
+    const ui = (link.data.meta?.ui as { preferredSize?: { height?: number } } | undefined);
+    if (ui?.preferredSize?.height) setHeight(ui.preferredSize.height);
+  }, [link.data.meta]);
+
+  // 3. postMessage relay. The host listens for `mcp-ui:*` from the inner
+  //    iframe and either auto-handles (link/size) or delegates to onAction.
+  useEffect(() => {
+    const inner = iframeRef.current?.contentWindow;
+    const onMessage = (e: MessageEvent) => {
+      const d = e.data as { type?: string; payload?: unknown } | null;
+      if (!d || typeof d !== 'object' || typeof d.type !== 'string') return;
+      if (!d.type.startsWith('mcp-ui:')) return;
+      if (inner && e.source !== inner) return;
+
+      switch (d.type) {
+        case 'mcp-ui:size': {
+          const h = (d.payload as { height?: number } | null)?.height;
+          if (typeof h === 'number' && h > 0) {
+            setHeight(Math.min(h, 2400));
+          }
+          break;
+        }
+        case 'mcp-ui:link': {
+          const url = (d.payload as { url?: string } | null)?.url;
+          if (url) window.open(url, '_blank', 'noopener,noreferrer');
+          onAction?.({ type: d.type, payload: d.payload });
+          break;
+        }
+        case 'mcp-ui:ready':
+        case 'mcp-ui:tool':
+        case 'mcp-ui:prompt':
+        case 'mcp-ui:notify':
+        default:
+          onAction?.({ type: d.type, payload: d.payload });
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [onAction]);
+
+  if (error) {
+    return (
+      <div className="my-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs text-destructive">
+        Couldn't load Zippy view: {error}
+      </div>
+    );
+  }
+
+  if (html == null) {
+    return (
+      <div className="my-2 rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+        Loading {toolName}…
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 overflow-hidden rounded-md border bg-background">
+      <iframe
+        ref={iframeRef}
+        title={toolName}
+        srcDoc={html}
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-modals"
+        style={{ width: '100%', height: `${height}px`, border: 0, display: 'block' }}
+      />
+    </div>
+  );
+};

--- a/packages/react/src/components/renderers/ToolExecutionRenderer.tsx
+++ b/packages/react/src/components/renderers/ToolExecutionRenderer.tsx
@@ -7,6 +7,7 @@ import { getToolSummary } from './tools/getToolSummary';
 import { MinimalToolRow } from './tools/MinimalToolRow';
 import { RichToolCard } from './tools/RichToolCard';
 import { InteractiveToolCard } from './tools/InteractiveToolCard';
+import { MCPAppRenderer, findResourceLinks, isMcpAppResource } from './MCPAppRenderer';
 
 interface ToolExecutionRendererProps {
   event: any; // Can be ToolCallsEvent or ToolResultsEvent
@@ -350,6 +351,26 @@ export const ToolExecutionRenderer: React.FC<ToolExecutionRendererProps> = ({
             <div key={toolCall.tool_call_id}>
               {renderer({ toolCall: toolCallPayload, state })}
             </div>
+          );
+        }
+
+        // MCP-Apps: if the tool result carries a `ui://` resource link
+        // with the mcp-app MIME profile, render it in a sandboxed iframe.
+        // Skipped if a user-provided custom renderer already matched
+        // above — explicit renderers always win.
+        const mcpLinks = findResourceLinks(state.result);
+        if (mcpLinks.some(isMcpAppResource)) {
+          const toolCallPayload: ToolCall = {
+            tool_call_id: toolCall.tool_call_id,
+            tool_name: toolCall.tool_name,
+            input: toolCall.input,
+          };
+          return (
+            <MCPAppRenderer
+              key={toolCall.tool_call_id}
+              toolCall={toolCallPayload}
+              state={state}
+            />
           );
         }
 

--- a/packages/react/src/components/renderers/index.ts
+++ b/packages/react/src/components/renderers/index.ts
@@ -1,5 +1,7 @@
 export * from './AssistantMessageRenderer';
 export { ToolExecutionRenderer, formatStatusText } from './ToolExecutionRenderer';
+export { MCPAppRenderer, findResourceLinks, isMcpAppResource } from './MCPAppRenderer';
+export type { MCPAppRendererProps } from './MCPAppRenderer';
 export * from './ImageRenderer';
 export * from './LoadingAnimation';
 export * from './MessageFeedback';


### PR DESCRIPTION
## Summary

Wires distrijs as an MCP-Apps host so workspace-registered MCP servers can return `ui://` resources and have them rendered inline as sandboxed iframes inside the chat — same pattern Claude and ChatGPT use, now in distrijs.

- `@distri/core`: new `ResourceLinkPart` on the `DistriPart` union, mirroring the Rust `distri_types::ResourceLink` struct (distrihub/distri#98).
- `@distri/react`: new `MCPAppRenderer` (sandboxed iframe, auto-resize via `mcp-ui:size`, opens `mcp-ui:link` URLs in new tabs, forwards `mcp-ui:tool|prompt|notify` to an `onAction` callback). Honours `_meta.ui.preferredSize.height` and prefers `_meta.ui.iframeUrl` (`src=`) over inline HTML (`srcDoc=`) when both are present — so widgets that already live on their own origin (Zippy's `/embed/new` and `/embed/learn`) skip the `resources/read` round-trip.
- `ToolExecutionRenderer`: dispatches automatically when a tool result carries a `ResourceLinkPart` with the `text/html;profile=mcp-app` MIME profile. Explicit user-provided `toolRenderers` still win first.
- All exported alongside the other renderers so app authors can also mount it directly (e.g. for a workspace MCP-apps panel that bypasses the agent loop).

Pairs with:
- distrihub/distri#98 — `Part::ResourceLink` + `mcp_tool.rs` propagation
- distrihub/distri-cloud#94 — Zippy MCP server returning the `ui://zippy/{new,learn}/<id>` resources

## Test plan

- [ ] `pnpm install && pnpm type-check && pnpm lint`
- [ ] Register the Zippy MCP server in a workspace (`POST /v1/mcp_servers`) pointing at a deployment of distri-cloud#94.
- [ ] In distrijs chat, ask the agent to "open the Zippy composer" — `zippy.compose` should fire and the iframe should render inline.
- [ ] Same with "show me lesson <id>" → `zippy.learn` renders.
- [ ] Verify auto-resize works (iframe grows with content) and that `mcp-ui:link` events open in a new tab.

https://claude.ai/code/session_01NfGERvcCnD8SjYLSAFsuaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfGERvcCnD8SjYLSAFsuaG)_