### PR TITLE
Add nested tasks mode with collapsible SubTaskTree component

### DIFF
--- a/packages/react/src/components/Chat.tsx
+++ b/packages/react/src/components/Chat.tsx
@@ -3,6 +3,7 @@ import { Agent, DistriChatMessage, DistriMessage, DistriPart, DistriThread, Tool
 import { ChatInput, AttachedImage } from './ChatInput';
 import { useChat } from '../useChat';
 import { MessageRenderer } from './renderers/MessageRenderer';
+import { SubTaskTree } from './renderers/SubTaskTree';
 import { MessageReadProvider } from './renderers/MessageReadContext';
 import { LoadingStrip } from './renderers/LoadingStrip';
 import { TodosCompact } from './renderers/TodosCompact';
@@ -115,6 +116,13 @@ export interface ChatProps {
   onCommand?: (event: ChatCommandEvent) => void;
   /** Developer mode options: traces, verbosity, tools panel, and parallel diagnose mode */
   developerMode?: DeveloperMode;
+  /**
+   * Group sub-agent activity under collapsible accordion cards instead of
+   * streaming it inline. Sub-task events (anything with a parentTaskId)
+   * are hoisted out of the main message list and rendered by
+   * `<SubTaskTree />` underneath the parent run.
+   */
+  nestedTasksMode?: boolean;
 }
 
 // Wrapper component to ensure consistent width and centering
@@ -223,6 +231,7 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
   sessionSettings,
   onCommand,
   developerMode,
+  nestedTasksMode = false,
 }, ref) {
   const [input, setInput] = useState(initialInput ?? '');
   const initialInputRef = useRef(initialInput ?? '');
@@ -891,6 +900,7 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
           threadId={threadId}
           enableFeedback={enableFeedback}
           onShowTrace={traceOpener}
+          nestedTasksMode={nestedTasksMode}
         />
       );
 
@@ -1169,6 +1179,17 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
                 {emptyStateContent}
                 {/* Render all messages and state */}
                 {renderMessages()}
+
+                {nestedTasksMode && (
+                  <SubTaskTree
+                    toolRenderers={mergedToolRenderers}
+                    rendering={rendering}
+                    threadId={threadId}
+                    onShowTrace={traceOpener}
+                    verbose={verbose}
+                    debug={tracesEnabled}
+                  />
+                )}
 
                 {renderExternalToolCalls()}
                 {/* Render pending message */}

--- a/packages/react/src/components/renderers/MessageRenderer.tsx
+++ b/packages/react/src/components/renderers/MessageRenderer.tsx
@@ -24,6 +24,12 @@ export interface MessageRendererProps {
   rendering?: RenderingMode;
   toolSummaryOverrides?: Record<string, SummaryFn>;
   onShowTrace?: (threadId: string) => void;
+  /**
+   * When true, suppress inline rendering of any event/message that belongs
+   * to a sub-task (has a `parentTaskId`). The caller is expected to mount
+   * a `<SubTaskTree />` to surface those sub-tasks in a nested accordion.
+   */
+  nestedTasksMode?: boolean;
 }
 
 // Wrapper component to ensure full width with max constraint for readability
@@ -53,8 +59,17 @@ export function MessageRenderer({
   rendering,
   toolSummaryOverrides,
   onShowTrace,
+  nestedTasksMode = false,
 }: MessageRendererProps): React.ReactNode {
   const toolCallsState = useChatStateStore(state => state.toolCalls);
+
+  // When nested-task mode is on, the SubTaskTree owns rendering for any
+  // event/message belonging to a sub-agent. Bail before the switch so
+  // the same content doesn't appear twice.
+  if (nestedTasksMode) {
+    const parentTaskId = (message as { parentTaskId?: string }).parentTaskId;
+    if (parentTaskId) return null;
+  }
 
   const rendererContextValue = useMemo(() => ({
     rendering: rendering ?? 'minimal',

--- a/packages/react/src/components/renderers/SubTaskCard.tsx
+++ b/packages/react/src/components/renderers/SubTaskCard.tsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  ChevronRight,
+  ChevronDown,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  GitBranch,
+} from 'lucide-react';
+import { isDistriEvent, isDistriMessage, DistriChatMessage } from '@distri/core';
+import { useChatStateStore, TaskState } from '@/stores/chatStateStore';
+import { MessageRenderer } from './MessageRenderer';
+import { ToolRendererMap, RenderingMode, SummaryFn } from '@/types';
+
+export interface SubTaskCardProps {
+  task: TaskState;
+  depth: number;
+  toolRenderers?: ToolRendererMap;
+  rendering?: RenderingMode;
+  toolSummaryOverrides?: Record<string, SummaryFn>;
+  threadId?: string;
+  onShowTrace?: (threadId: string) => void;
+  verbose?: boolean;
+  debug?: boolean;
+}
+
+function StatusIcon({ status }: { status: TaskState['status'] }) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="h-3 w-3 text-primary animate-spin flex-shrink-0" />;
+    case 'completed':
+      return <CheckCircle2 className="h-3 w-3 text-primary flex-shrink-0" />;
+    case 'failed':
+      return <XCircle className="h-3 w-3 text-destructive flex-shrink-0" />;
+    default:
+      return <GitBranch className="h-3 w-3 text-muted-foreground flex-shrink-0" />;
+  }
+}
+
+/**
+ * Best-effort title derivation: agent name from event envelope, else the
+ * first piece of streamed text, else the task id tail.
+ */
+function deriveTitle(messages: DistriChatMessage[], task: TaskState): string {
+  if (task.title && task.title !== 'Agent Run') return task.title;
+  for (const m of messages) {
+    if (isDistriEvent(m) && m.taskId === task.id) {
+      const e = m as { type: string; data?: { agentId?: string } };
+      if (e.type === 'run_started' && e.data?.agentId) return e.data.agentId;
+    }
+  }
+  for (const m of messages) {
+    if (isDistriMessage(m) && (m as { taskId?: string }).taskId === task.id) {
+      const text = m.parts
+        ?.filter((p) => p.part_type === 'text')
+        .map((p) => (p as { data: string }).data)
+        .join('')
+        .trim();
+      if (text) return text.slice(0, 80);
+    }
+  }
+  return `subtask ${task.id.slice(0, 8)}`;
+}
+
+export const SubTaskCard: React.FC<SubTaskCardProps> = ({
+  task,
+  depth,
+  toolRenderers,
+  rendering,
+  toolSummaryOverrides,
+  threadId,
+  onShowTrace,
+  verbose,
+  debug,
+}) => {
+  const messages = useChatStateStore((s) => s.messages);
+  const tasks = useChatStateStore((s) => s.tasks);
+
+  const childTasks = useMemo(
+    () =>
+      task.childTaskIds
+        .map((id) => tasks.get(id))
+        .filter((t): t is TaskState => !!t),
+    [task.childTaskIds, tasks],
+  );
+
+  const ownMessages = useMemo(
+    () =>
+      messages.filter((m) => {
+        const taskId = (m as { taskId?: string }).taskId;
+        return taskId === task.id;
+      }),
+    [messages, task.id],
+  );
+
+  // Default: expand while running, collapse when completed.
+  const [expanded, setExpanded] = useState(task.status === 'running');
+  const [userToggled, setUserToggled] = useState(false);
+  useEffect(() => {
+    if (userToggled) return;
+    if (task.status === 'running') setExpanded(true);
+    if (task.status === 'completed') setExpanded(false);
+  }, [task.status, userToggled]);
+
+  const title = deriveTitle(messages, task);
+  const indent = depth * 12;
+
+  return (
+    <div
+      className="rounded-md border border-border bg-muted/20 overflow-hidden text-xs"
+      style={{ marginLeft: indent }}
+    >
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-muted/40 cursor-pointer select-none"
+        onClick={() => {
+          setExpanded((e) => !e);
+          setUserToggled(true);
+        }}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+        )}
+        <StatusIcon status={task.status} />
+        <span className="font-medium text-foreground truncate flex-1 text-left">{title}</span>
+        {task.status === 'running' && (
+          <span className="text-[10px] text-muted-foreground flex-shrink-0">running…</span>
+        )}
+        {task.status === 'completed' && task.startTime && task.endTime && (
+          <span className="text-[10px] text-muted-foreground flex-shrink-0">
+            {((task.endTime - task.startTime) / 1000).toFixed(1)}s
+          </span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border bg-background/40 px-2 py-2 space-y-1">
+          {ownMessages.map((message, index) => (
+            <MessageRenderer
+              key={`${task.id}-${index}`}
+              message={message}
+              index={index}
+              toolRenderers={toolRenderers}
+              rendering={rendering}
+              toolSummaryOverrides={toolSummaryOverrides}
+              threadId={threadId}
+              onShowTrace={onShowTrace}
+              verbose={verbose}
+              debug={debug}
+            />
+          ))}
+          {childTasks.map((child) => (
+            <SubTaskCard
+              key={child.id}
+              task={child}
+              depth={depth + 1}
+              toolRenderers={toolRenderers}
+              rendering={rendering}
+              toolSummaryOverrides={toolSummaryOverrides}
+              threadId={threadId}
+              onShowTrace={onShowTrace}
+              verbose={verbose}
+              debug={debug}
+            />
+          ))}
+          {task.error && (
+            <div className="px-2 py-1 text-destructive text-xs rounded bg-destructive/10">
+              {task.error}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/react/src/components/renderers/SubTaskTree.tsx
+++ b/packages/react/src/components/renderers/SubTaskTree.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import { useChatStateStore, TaskState } from '@/stores/chatStateStore';
+import { SubTaskCard } from './SubTaskCard';
+import { ToolRendererMap, RenderingMode, SummaryFn } from '@/types';
+
+export interface SubTaskTreeProps {
+  /**
+   * Optional explicit root. When omitted, picks every task in the store
+   * that has no parent — typically just one per turn.
+   */
+  rootTaskId?: string;
+  toolRenderers?: ToolRendererMap;
+  rendering?: RenderingMode;
+  toolSummaryOverrides?: Record<string, SummaryFn>;
+  threadId?: string;
+  onShowTrace?: (threadId: string) => void;
+  verbose?: boolean;
+  debug?: boolean;
+  /**
+   * Hide the root task and only show its descendants. Default true —
+   * the root task's events render inline in the main message list, so
+   * the tree only needs to surface sub-agents.
+   */
+  hideRoot?: boolean;
+}
+
+/**
+ * Walks the task dispatch tree from chat state and renders every
+ * sub-task as a collapsible card. Intended to be mounted alongside the
+ * main message list so sub-agent activity is grouped under one
+ * accordion per task instead of streaming inline with the parent.
+ */
+export const SubTaskTree: React.FC<SubTaskTreeProps> = ({
+  rootTaskId,
+  hideRoot = true,
+  ...rest
+}) => {
+  const tasks = useChatStateStore((s) => s.tasks);
+
+  const roots = useMemo(() => {
+    if (rootTaskId) {
+      const t = tasks.get(rootTaskId);
+      return t ? [t] : [];
+    }
+    return Array.from(tasks.values()).filter((t) => !t.parentTaskId);
+  }, [tasks, rootTaskId]);
+
+  const cards = useMemo(() => {
+    const out: { task: TaskState; depth: number }[] = [];
+    for (const root of roots) {
+      if (!hideRoot) out.push({ task: root, depth: 0 });
+      for (const childId of root.childTaskIds) {
+        const child = tasks.get(childId);
+        if (child) out.push({ task: child, depth: hideRoot ? 0 : 1 });
+      }
+    }
+    return out;
+  }, [roots, tasks, hideRoot]);
+
+  if (cards.length === 0) return null;
+
+  return (
+    <div className="w-full px-4 my-2 space-y-1">
+      <div className="max-w-4xl mx-auto space-y-1">
+        {cards.map(({ task, depth }) => (
+          <SubTaskCard key={task.id} task={task} depth={depth} {...rest} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/components/renderers/index.ts
+++ b/packages/react/src/components/renderers/index.ts
@@ -6,6 +6,8 @@ export * from './MessageFeedback';
 export * from './MessageReadContext';
 export * from './MessageReadTracker';
 export * from './MessageRenderer';
+export * from './SubTaskCard';
+export * from './SubTaskTree';
 export * from './StepBasedRenderer';
 export * from './StreamingTextRenderer';
 export * from './TextRenderer';


### PR DESCRIPTION
## Summary
Introduces a new `nestedTasksMode` feature that groups sub-agent activity under collapsible accordion cards instead of streaming it inline with the main message list. This improves readability when dealing with multi-level agent hierarchies by hoisting sub-task events out of the main message flow.

## Key Changes

- **New `SubTaskCard` component** (`packages/react/src/components/renderers/SubTaskCard.tsx`):
  - Renders individual task as a collapsible card with status indicator (running/completed/failed)
  - Displays task title derived from agent ID, streamed text, or task ID
  - Shows execution duration for completed tasks
  - Recursively renders child tasks with proper indentation
  - Displays task-specific messages and error states
  - Auto-expands while running, auto-collapses when completed (respects user toggle)

- **New `SubTaskTree` component** (`packages/react/src/components/renderers/SubTaskTree.tsx`):
  - Walks the task dispatch tree from chat state and renders all sub-tasks
  - Supports optional explicit root task or auto-detects root tasks (those without parent)
  - `hideRoot` option (default `true`) to suppress root task rendering since it streams inline
  - Passes through tool renderers, rendering mode, and trace callbacks to child cards

- **Updated `Chat` component**:
  - Added `nestedTasksMode` prop to enable the feature
  - Mounts `<SubTaskTree />` alongside main message list when enabled
  - Passes necessary context (tool renderers, thread ID, trace handler) to the tree

- **Updated `MessageRenderer` component**:
  - Added `nestedTasksMode` prop to suppress inline rendering of sub-task messages
  - When enabled, skips rendering any event/message with a `parentTaskId` to avoid duplication
  - Allows `SubTaskTree` to own the rendering of sub-agent activity

- **Updated exports** in `packages/react/src/components/renderers/index.ts` to expose new components

## Implementation Details

- Uses Zustand store selectors to access task hierarchy and messages
- Memoizes child task lookups and message filtering for performance
- Leverages existing `MessageRenderer` for consistent message display within cards
- Follows shadcn/ui design patterns with Tailwind styling and Lucide icons
- Supports all existing tool renderer and rendering mode configurations

https://claude.ai/code/session_01ULpDNakU5M81gNoUpgs1Rq