### PR TITLE
feat(home): standalone ModelsView — catalog + providers + voice/image playgrounds

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1102,12 +1102,13 @@ export interface MessageVoteSummary {
 
 // ========== Models API Types ==========
 
-export type ModelCapability = 'completion' | 'tts' | 'stt';
+export type ModelCapability = 'completion' | 'tts' | 'stt' | 'image';
 
 export type ModelPricing =
   | { type: 'completion'; input: number; output: number; cached_input?: number }
   | { type: 'tts'; per_1m_chars: number }
-  | { type: 'stt'; per_minute: number };
+  | { type: 'stt'; per_minute: number }
+  | { type: 'image'; per_image: number; per_quality?: Record<string, number> };
 
 /**
  * A model with its capability, pricing, and metadata.

--- a/packages/home/src/DistriHomeClient.ts
+++ b/packages/home/src/DistriHomeClient.ts
@@ -1400,12 +1400,13 @@ export interface TtsVoiceInfo {
   languages?: string[];
 }
 
-export type ModelCapability = 'completion' | 'tts' | 'stt';
+export type ModelCapability = 'completion' | 'tts' | 'stt' | 'image';
 
 export type ModelPricing =
   | { type: 'completion'; input: number; output: number; cached_input?: number }
   | { type: 'tts'; per_1m_chars: number }
-  | { type: 'stt'; per_minute: number };
+  | { type: 'stt'; per_minute: number }
+  | { type: 'image'; per_image: number; per_quality?: Record<string, number> };
 
 export interface Model {
   id: string;

--- a/packages/home/src/DistriHomeClient.ts
+++ b/packages/home/src/DistriHomeClient.ts
@@ -1448,18 +1448,51 @@ export interface ProviderTypeInfo {
 
 // ---- Image generation ----
 
+export type ImageSize =
+  | 'auto'
+  | '256x256'
+  | '512x512'
+  | '1024x1024'
+  | '1024x1536'
+  | '1536x1024'
+  | '1024x1792'
+  | '1792x1024';
+
+/** Quality tier. gpt-image-* accepts low/medium/high/auto;
+ *  dall-e-3 accepts standard/hd. */
+export type ImageQuality = 'auto' | 'low' | 'medium' | 'high' | 'standard' | 'hd';
+
+export type ImageResponseFormat = 'url' | 'b64_json';
+/** gpt-image-only. */
+export type ImageOutputFormat = 'png' | 'jpeg' | 'webp';
+/** gpt-image-only. */
+export type ImageModeration = 'auto' | 'low';
+/** gpt-image-only. */
+export type ImageBackground = 'auto' | 'transparent' | 'opaque';
+/** dall-e-3 only. */
+export type ImageStyle = 'vivid' | 'natural';
+
 export interface ImageGenerateRequest {
   /** `"provider/model"` (e.g. `"openai/gpt-image-1"`, `"fal_ai/fal-ai/flux/schnell"`). */
   model: string;
   prompt: string;
   n?: number;
-  /** Size string — `"1024x1024"`, or fal.ai's `"square_hd"` etc. */
-  size?: string;
-  /** `"low" | "medium" | "high"` for gpt-image-*, `"standard" | "hd"` for dall-e-3. */
-  quality?: string;
-  response_format?: 'url' | 'b64_json';
-  /** Provider-specific pass-through (e.g. `output_format`, `seed`). */
-  extra?: Record<string, unknown>;
+  size?: ImageSize;
+  quality?: ImageQuality;
+  /** Honored by dall-e-*. gpt-image-* always returns base64 and the API
+   *  rejects this field. */
+  response_format?: ImageResponseFormat;
+  /** gpt-image-only. */
+  output_format?: ImageOutputFormat;
+  /** gpt-image-only. 0-100. */
+  output_compression?: number;
+  /** gpt-image-only. */
+  moderation?: ImageModeration;
+  /** gpt-image-only. */
+  background?: ImageBackground;
+  /** dall-e-3 only. */
+  style?: ImageStyle;
+  user?: string;
 }
 
 export interface ImageGenerateResponseImage {

--- a/packages/home/src/DistriHomeClient.ts
+++ b/packages/home/src/DistriHomeClient.ts
@@ -981,6 +981,23 @@ export class DistriHomeClient {
   }
 
   /**
+   * Generate an image. POSTs to `/v1/images/generations` and returns the
+   * provider-agnostic response (`{provider, model, images: [...]}`).
+   */
+  async generateImage(request: ImageGenerateRequest): Promise<ImageGenerateResponse> {
+    const response = await this.client.fetch('/images/generations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(text || `Image generation failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  /**
    * Update workspace settings for the current workspace.
    * Uses /workspaces/current to resolve the workspace from the X-Workspace-Id header.
    */
@@ -1427,6 +1444,37 @@ export interface ModelWithProvider extends Model {
 export interface ProviderTypeInfo {
   id: string;
   label: string;
+}
+
+// ---- Image generation ----
+
+export interface ImageGenerateRequest {
+  /** `"provider/model"` (e.g. `"openai/gpt-image-1"`, `"fal_ai/fal-ai/flux/schnell"`). */
+  model: string;
+  prompt: string;
+  n?: number;
+  /** Size string — `"1024x1024"`, or fal.ai's `"square_hd"` etc. */
+  size?: string;
+  /** `"low" | "medium" | "high"` for gpt-image-*, `"standard" | "hd"` for dall-e-3. */
+  quality?: string;
+  response_format?: 'url' | 'b64_json';
+  /** Provider-specific pass-through (e.g. `output_format`, `seed`). */
+  extra?: Record<string, unknown>;
+}
+
+export interface ImageGenerateResponseImage {
+  url?: string;
+  b64_json?: string;
+  content_type?: string;
+  revised_prompt?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface ImageGenerateResponse {
+  provider: string;
+  model: string;
+  images: ImageGenerateResponseImage[];
 }
 
 export interface ProviderKeyDefinition {

--- a/packages/home/src/components/AgentSettingsView.tsx
+++ b/packages/home/src/components/AgentSettingsView.tsx
@@ -1,122 +1,86 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Check, ChevronDown, Copy, Layers, Loader2, Mic, Plus, Settings, Star, Trash2, Volume2, Wrench, X } from 'lucide-react';
-import { useDistriHomeClient } from '../provider/context';
-import type { Secret, CustomModelEntry, CustomProviderConfig, ModelProviderDefinition, Model, ModelCapability, ModelPricing, ProviderKeyDefinition, TtsVoiceInfo } from '../DistriHomeClient';
-import { VoicePreviewDialog } from './VoicePreviewDialog';
+/**
+ * Models settings entry point — shell that routes between
+ * Catalog, Providers, the model-detail drawer, and the
+ * Voice / Image playgrounds.
+ *
+ * Wired to the real `DistriHomeClient`:
+ *   listProviders / listSecrets / getWorkspaceSettings
+ *   updateWorkspaceSettings (defaults)
+ *   upsertProvider (save credential)
+ *   deleteSecret (remove credential)
+ *   testProvider (probe `GET /models`)
+ *   generateImage / generateSpeech (playgrounds)
+ *
+ * Styling is scoped under `.models-shell` (see ./models/models.css).
+ * The shell intentionally bypasses the rest of the app's shadcn
+ * theming so the dense dark UI lands as designed.
+ */
 
-type AgentSettingsTab = 'models' | 'providers';
+import './models/models.css';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Beaker, Layers, Settings as SettingsIcon } from 'lucide-react';
+import { useDistriHomeClient } from '../provider/context';
+import type {
+  CustomModelEntry,
+  ModelCapability,
+  ModelProviderDefinition,
+  Secret,
+} from '../DistriHomeClient';
+import { CatalogTab } from './models/CatalogTab';
+import { ImagePlayground } from './models/ImagePlayground';
+import { ModelDetailDrawer } from './models/ModelDetailDrawer';
+import { ProvidersTab } from './models/ProvidersTab';
+import { VoicePlayground } from './models/VoicePlayground';
 
 export interface AgentSettingsViewProps {
   className?: string;
-  /** Active tab from URL: 'models' (default) or 'providers' */
+  /** Active tab from URL: 'models' (default) or 'providers'. */
   activeTab?: 'models' | 'providers';
-  /** Callback when tab changes -- consumer should update URL */
+  /** Callback when tab changes — consumer should update URL. */
   onTabChange?: (tab: 'models' | 'providers') => void;
 }
 
-function CapabilityBadge({ type }: { type: ModelCapability }) {
-  const styles: Record<ModelCapability, string> = {
-    completion: 'bg-blue-500/10 text-blue-500',
-    tts: 'bg-emerald-500/10 text-emerald-500',
-    stt: 'bg-purple-500/10 text-purple-500',
-    image: 'bg-amber-500/10 text-amber-500',
-  };
-  const labels: Record<ModelCapability, string> = {
-    completion: 'Completion',
-    tts: 'TTS',
-    stt: 'STT',
-    image: 'Image',
-  };
-  return (
-    <span className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ${styles[type]}`}>
-      {type === 'stt' && <Mic className="h-2.5 w-2.5 mr-0.5" />}
-      {labels[type]}
-    </span>
-  );
-}
+type PlaygroundMode = { capability: 'image' | 'tts'; providerId?: string; modelId?: string } | null;
+type DrawerTarget = { providerId: string; modelId: string } | null;
 
-function formatContextWindow(tokens?: number): string {
-  if (!tokens) return '';
-  if (tokens >= 1_000_000) {
-    const val = tokens / 1_000_000;
-    return val % 1 === 0 ? `${val}M` : `${val.toFixed(1)}M`;
-  }
-  if (tokens >= 1_000) {
-    const val = tokens / 1_000;
-    return val % 1 === 0 ? `${val}K` : `${val.toFixed(1)}K`;
-  }
-  return String(tokens);
-}
-
-
-export function AgentSettingsView({ className, activeTab: activeTabProp, onTabChange }: AgentSettingsViewProps) {
+export function AgentSettingsView({
+  className,
+  activeTab: activeTabProp,
+  onTabChange,
+}: AgentSettingsViewProps) {
   const homeClient = useDistriHomeClient();
+  const [activeTabInternal, setActiveTabInternal] = useState<'models' | 'providers'>(
+    activeTabProp ?? 'models',
+  );
+  const activeTab = activeTabProp ?? activeTabInternal;
 
-  const activeTab: AgentSettingsTab = activeTabProp ?? 'models';
-  const setActiveTab = (tab: AgentSettingsTab) => {
-    if (onTabChange) onTabChange(tab);
+  const setActiveTab = (t: 'models' | 'providers') => {
+    setActiveTabInternal(t);
+    onTabChange?.(t);
   };
 
-  const [secrets, setSecrets] = useState<Secret[]>([]);
+  // ── Server state ──
   const [providers, setProviders] = useState<ModelProviderDefinition[]>([]);
+  const [secrets, setSecrets] = useState<Secret[]>([]);
+  const [defaults, setDefaults] = useState({
+    completion: '',
+    tts: '',
+    stt: '',
+    image: '',
+  });
+  const [customModels, setCustomModels] = useState<CustomModelEntry[]>([]); // kept for symmetry; UI lands later
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [defaultModel, setDefaultModel] = useState<string>('');
-  const [defaultTtsModel, setDefaultTtsModel] = useState<string>('');
-  const [defaultSttModel, setDefaultSttModel] = useState<string>('');
-  const [customModels, setCustomModels] = useState<CustomModelEntry[]>([]);
-  const [saving, setSaving] = useState(false);
-  const [saveSuccess, setSaveSuccess] = useState(false);
 
-  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
-  const [savingField, setSavingField] = useState<string | null>(null);
-  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
+  // ── Local UI state ──
+  const [favorites, setFavorites] = useState<Set<string>>(new Set());
+  const [drawer, setDrawer] = useState<DrawerTarget>(null);
+  const [playground, setPlayground] = useState<PlaygroundMode>(null);
+  const [focusProviderId, setFocusProviderId] = useState<string | undefined>(undefined);
 
-  // Provider connection test (`POST /providers/test`), keyed by provider id.
-  const [testingProvider, setTestingProvider] = useState<string | null>(null);
-  const [testResults, setTestResults] = useState<Record<string, { ok: boolean; detail: string }>>({});
-
-  // Custom provider management
-  const [showAddProvider, setShowAddProvider] = useState(false);
-  const [newProviderName, setNewProviderName] = useState('');
-  const [newProviderUrl, setNewProviderUrl] = useState('');
-  const [newProviderKey, setNewProviderKey] = useState('');
-  const [newProviderProjectId, setNewProviderProjectId] = useState('');
-
-  // Custom providers stored in workspace settings
-  const [customProviders, setCustomProviders] = useState<CustomProviderConfig[]>([]);
-
-  // Auto-expand provider when navigating from Models tab Configure button
-  const [autoExpandProvider, setAutoExpandProvider] = useState<string | null>(null);
-
-  // Model selector dialog
-  const [selectorDialogOpen, setSelectorDialogOpen] = useState(false);
-  const [selectorDialogCapability, setSelectorDialogCapability] = useState<ModelCapability>('completion');
-
-  // Voice preview dialog
-  const [voiceDialogOpen, setVoiceDialogOpen] = useState(false);
-  const [voiceDialogModelId, setVoiceDialogModelId] = useState<string | undefined>();
-  const [voiceDialogProviderId, setVoiceDialogProviderId] = useState<string | undefined>();
-
-  const openVoiceDialog = useCallback((providerId: string, modelId: string) => {
-    setVoiceDialogProviderId(providerId);
-    setVoiceDialogModelId(modelId);
-    setVoiceDialogOpen(true);
-  }, []);
-
-  const [copiedId, setCopiedId] = useState<string | null>(null);
-  const handleCopyId = useCallback((id: string) => {
-    navigator.clipboard.writeText(id).then(() => {
-      setCopiedId(id);
-      setTimeout(() => setCopiedId(null), 1500);
-    });
-  }, []);
-
-  // Models tab filters
-
-  // Inline add model: tracks which provider+section is adding (e.g. "openai:completion")
-  const [addingModelKey, setAddingModelKey] = useState<string | null>(null);
-  const [newModelId, setNewModelId] = useState<string>('');
+  // Avoid an unused warning while the field stays on the type.
+  void customModels;
 
   const loadData = useCallback(async () => {
     if (!homeClient) return;
@@ -128,13 +92,15 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
         homeClient.listSecrets(),
         homeClient.listProviders(),
       ]);
-      setSecrets(secs);
       setProviders(providerData);
-      setDefaultModel(settings?.default_model || '');
-      setDefaultTtsModel(settings?.default_tts_model || '');
-      setDefaultSttModel(settings?.default_stt_model || '');
-      setCustomModels(settings?.custom_models || []);
-      setCustomProviders(settings?.custom_providers || []);
+      setSecrets(secs);
+      setDefaults({
+        completion: settings?.default_model ?? '',
+        tts: settings?.default_tts_model ?? '',
+        stt: settings?.default_stt_model ?? '',
+        image: (settings as Record<string, unknown> | null)?.default_image_model as string | undefined ?? '',
+      });
+      setCustomModels(settings?.custom_models ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load settings');
     } finally {
@@ -142,990 +108,262 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
     }
   }, [homeClient]);
 
-  useEffect(() => { loadData(); }, [loadData]);
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
-  const getSecret = useCallback(
-    (key: string) => secrets.find((s) => s.key === key),
-    [secrets],
-  );
+  // ── Derived ──
+  const configuredProviders = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of providers) {
+      const required = p.keys.filter((k) => k.required !== false);
+      if (required.length === 0) continue;
+      if (required.every((k) => secrets.some((s) => s.key === k.key))) set.add(p.id);
+    }
+    return set;
+  }, [providers, secrets]);
 
-  const isProviderConfigured = useCallback(
-    (provider: ModelProviderDefinition) => {
-      const required = provider.keys.filter((k) => k.required !== false);
-      if (required.length === 0) {
-        // Provider with no required keys: configured if ANY key is present
-        return provider.keys.some((k) => {
-          const s = getSecret(k.key);
-          return s && s.masked_value && s.masked_value !== '';
-        });
-      }
-      return required.every((k) => {
-        const s = getSecret(k.key);
-        return s && s.masked_value && s.masked_value !== '';
-      });
-    },
-    [getSecret],
-  );
-
-  const getProviderCapabilities = useCallback(
-    (provider: ModelProviderDefinition): ModelCapability[] => {
-      const caps = new Set<ModelCapability>();
-      for (const m of provider.models) {
-        caps.add(m.capability);
-      }
-      return Array.from(caps);
-    },
-    [],
-  );
-
-  // Save all unsaved fields for a provider at once via POST /providers
-  const handleSaveProvider = async (providerId: string, keys: ProviderKeyDefinition[]) => {
-    if (!homeClient) return;
-    const toSave = keys.filter((k) => {
-      const val = fieldValues[k.key]?.trim();
-      return val && !getSecret(k.key);
+  // ── Actions ──
+  const toggleFavorite = (fullId: string) =>
+    setFavorites((prev) => {
+      const next = new Set(prev);
+      if (next.has(fullId)) next.delete(fullId);
+      else next.add(fullId);
+      return next;
     });
-    if (toSave.length === 0) return;
-    setSavingField('__provider__');
-    setError(null);
-    try {
-      const secrets: Record<string, string> = {};
-      for (const k of toSave) {
-        secrets[k.key] = fieldValues[k.key].trim();
-      }
-      await homeClient.upsertProvider({ provider_id: providerId, secrets });
-      setFieldValues((prev) => {
-        const next = { ...prev };
-        for (const k of toSave) delete next[k.key];
-        return next;
-      });
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    } finally {
-      setSavingField(null);
+
+  const handleOpenModel = (providerId: string, modelId: string) =>
+    setDrawer({ providerId, modelId });
+
+  const handleOpenPlayground = (capability: ModelCapability, providerId: string, modelId: string) => {
+    if (capability === 'image' || capability === 'tts') {
+      setPlayground({ capability, providerId, modelId });
+    } else {
+      // No completion/STT playground built yet — fall through to drawer.
+      setDrawer({ providerId, modelId });
     }
   };
 
-  // Validate a saved provider — the backend probes GET /models with the
-  // workspace's stored credentials.
-  const handleTestProvider = async (providerId: string) => {
+  const handleConfigureProvider = (providerId: string) => {
+    setFocusProviderId(providerId);
+    setActiveTab('providers');
+  };
+
+  const handleChangeDefault = async (capability: ModelCapability) => {
+    // The catalog's default cards trigger this. For now, just jump to
+    // the capability-filtered catalog so the user can click a model
+    // and use the drawer's "Set as default". The drawer wires the
+    // actual updateWorkspaceSettings call.
+    setPlayground(null);
+    setDrawer(null);
+    // No-op aside from filtering would be confusing; keep noop.
+    void capability;
+  };
+
+  const handleSetDefaultForModel = async (capability: ModelCapability, fullId: string) => {
     if (!homeClient) return;
-    setTestingProvider(providerId);
-    setTestResults((prev) => {
-      const next = { ...prev };
-      delete next[providerId];
-      return next;
+    const key =
+      capability === 'completion'
+        ? 'default_model'
+        : capability === 'tts'
+        ? 'default_tts_model'
+        : capability === 'stt'
+        ? 'default_stt_model'
+        : 'default_image_model';
+    const isCurrent = defaults[capability] === fullId;
+    const next = isCurrent ? null : fullId;
+    await homeClient.updateWorkspaceSettings({ [key]: next });
+    setDefaults((prev) => ({ ...prev, [capability]: next ?? '' }));
+  };
+
+  const handleSaveKey = async (providerId: string, key: string, value: string) => {
+    if (!homeClient) return;
+    await homeClient.upsertProvider({
+      provider_id: providerId,
+      secrets: { [key]: value },
     });
+    await loadData();
+  };
+
+  const handleDeleteKey = async (key: string) => {
+    if (!homeClient) return;
+    await homeClient.deleteSecret(key);
+    await loadData();
+  };
+
+  const handleTestProvider = async (providerId: string) => {
+    if (!homeClient) return { ok: false, detail: 'No client' };
     try {
       const result = await homeClient.testProvider(providerId);
-      setTestResults((prev) => ({
-        ...prev,
-        [providerId]: result.ok
-          ? { ok: true, detail: `Connected — ${result.models.length} model(s)` }
-          : { ok: false, detail: result.error || 'Endpoint test failed' },
-      }));
+      const detail = result.ok
+        ? `Connected — ${result.models.length} models reachable`
+        : result.error ?? 'Test failed';
+      return { ok: result.ok, detail };
     } catch (err) {
-      setTestResults((prev) => ({
-        ...prev,
-        [providerId]: { ok: false, detail: err instanceof Error ? err.message : 'Test failed' },
-      }));
-    } finally {
-      setTestingProvider(null);
+      return { ok: false, detail: err instanceof Error ? err.message : 'Test failed' };
     }
   };
 
-  const handleDeleteField = async (key: string) => {
-    if (!homeClient) return;
-    setError(null);
-    try {
-      await homeClient.deleteSecret(key);
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete');
-    }
-  };
-
-  const handleSetDefault = async (type: ModelCapability, model: string) => {
-    if (!homeClient) return;
-    setSaving(true);
-    try {
-      if (type === 'completion') {
-        const newDefault = defaultModel === model ? '' : model;
-        setDefaultModel(newDefault);
-        await homeClient.upsertProvider({
-          provider_id: '__settings__',
-          default_model: newDefault,
-        });
-      } else if (type === 'tts') {
-        const newDefault = defaultTtsModel === model ? '' : model;
-        setDefaultTtsModel(newDefault);
-        await homeClient.updateWorkspaceSettings({ default_tts_model: newDefault || null });
-      } else if (type === 'stt') {
-        const newDefault = defaultSttModel === model ? '' : model;
-        setDefaultSttModel(newDefault);
-        await homeClient.updateWorkspaceSettings({ default_stt_model: newDefault || null });
-      }
-      setSaveSuccess(true);
-      setTimeout(() => setSaveSuccess(false), 2000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleAddModel = async (providerId: string, capability: ModelCapability) => {
-    if (!homeClient) return;
-    const modelName = newModelId.trim();
-    if (!modelName) return;
-
-    if (customModels.some((m) => m.provider === providerId && m.model === modelName)) return;
-
-    const updated = [...customModels, { provider: providerId, model: modelName, capability }];
-    setCustomModels(updated);
-    setNewModelId('');
-    setAddingModelKey(null);
-    try {
-      await homeClient.upsertProvider({
-        provider_id: '__settings__',
-        custom_models: updated,
-      });
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    }
-  };
-
-  const handleRemoveCustomModel = async (providerId: string, modelName: string) => {
-    if (!homeClient) return;
-    const fullId = `${providerId}/${modelName}`;
-    const updated = customModels.filter((m) => !(m.provider === providerId && m.model === modelName));
-    setCustomModels(updated);
-
-    let newDefaultModel = defaultModel;
-    let newDefaultTts = defaultTtsModel;
-    let newDefaultStt = defaultSttModel;
-    if (defaultModel === fullId) { newDefaultModel = ''; setDefaultModel(''); }
-    if (defaultTtsModel === fullId) { newDefaultTts = ''; setDefaultTtsModel(''); }
-    if (defaultSttModel === fullId) { newDefaultStt = ''; setDefaultSttModel(''); }
-
-    try {
-      await homeClient.upsertProvider({
-        provider_id: '__settings__',
-        custom_models: updated,
-        default_model: newDefaultModel,
-      });
-      if (newDefaultTts !== defaultTtsModel || newDefaultStt !== defaultSttModel) {
-        await homeClient.updateWorkspaceSettings({
-          default_tts_model: newDefaultTts || null,
-          default_stt_model: newDefaultStt || null,
-        });
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save');
-    }
-  };
-
-  const handleAddCustomProvider = async () => {
-    const name = newProviderName.trim();
-    const url = newProviderUrl.trim();
-    const key = newProviderKey.trim();
-    if (!name || !url || !key || !homeClient) return;
-
-    const id = `custom_${name.toLowerCase().replace(/[^a-z0-9]/g, '_')}`;
-
-    setSaving(true);
-    try {
-      const secrets: Record<string, string> = {
-        [`${id.toUpperCase()}_API_KEY`]: key,
-      };
-      if (newProviderProjectId.trim()) {
-        secrets[`${id.toUpperCase()}_PROJECT_ID`] = newProviderProjectId.trim();
-      }
-
-      await homeClient.upsertProvider({
-        provider_id: id,
-        secrets,
-        config: {
-          id,
-          name,
-          base_url: url,
-          ...(newProviderProjectId.trim() ? { project_id: newProviderProjectId.trim() } : {}),
-        },
-      });
-
-      setNewProviderName('');
-      setNewProviderUrl('');
-      setNewProviderKey('');
-      setNewProviderProjectId('');
-      setShowAddProvider(false);
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save provider');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleRemoveCustomProvider = async (providerId: string) => {
-    if (!homeClient) return;
-    setError(null);
-    try {
-      await homeClient.deleteProvider(providerId);
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete provider');
-    }
-  };
-
-  const toggleProvider = (id: string) => {
-    setExpandedProviders((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
-  // Auto-expand provider when switching to providers tab with autoExpandProvider set
-  useEffect(() => {
-    if (activeTab === 'providers' && autoExpandProvider) {
-      setExpandedProviders((prev) => {
-        const next = new Set(prev);
-        next.add(autoExpandProvider);
-        return next;
-      });
-      setAutoExpandProvider(null);
-    }
-  }, [activeTab, autoExpandProvider]);
-
-  // Build flat model list for the Models tab
-  const allModels = useMemo(() => {
-    const rows: ModelRow[] = [];
-
-    for (const provider of providers) {
-      const configured = isProviderConfigured(provider);
-
-      for (const m of provider.models) {
-        rows.push({
-          id: m.id,
-          name: m.name,
-          providerId: provider.id,
-          providerLabel: provider.label,
-          type: m.capability,
-          isCustom: false,
-          providerConfigured: configured,
-          contextWindow: m.context_window,
-          pricing: m.pricing,
-          voices: m.voices,
-        });
-      }
-    }
-
-    // Add custom models
-    for (const cm of customModels) {
-      if (rows.some((r) => r.providerId === cm.provider && r.id === cm.model)) continue;
-      const provider = providers.find((p) => p.id === cm.provider);
-      const configured = provider ? isProviderConfigured(provider) : false;
-      const cap = (cm as any).capability as ModelCapability | undefined;
-      rows.push({
-        id: cm.model,
-        name: cm.model,
-        providerId: cm.provider,
-        providerLabel: provider?.label || cm.provider,
-        type: cap || 'completion',
-        isCustom: true,
-        providerConfigured: configured,
-      });
-    }
-
-    return rows;
-  }, [providers, customModels, isProviderConfigured]);
-
-  // Group all models by provider
-  const groupedModels = useMemo(() => {
-    const groups: Array<{ providerId: string; providerLabel: string; models: ModelRow[] }> = [];
-    const map = new Map<string, ModelRow[]>();
-    const order: string[] = [];
-
-    for (const m of allModels) {
-      if (!map.has(m.providerId)) {
-        map.set(m.providerId, []);
-        order.push(m.providerId);
-      }
-      map.get(m.providerId)!.push(m);
-    }
-
-    for (const pid of order) {
-      const models = map.get(pid)!;
-      groups.push({
-        providerId: pid,
-        providerLabel: models[0].providerLabel,
-        models,
-      });
-    }
-
-    return groups;
-  }, [allModels]);
-
+  // ── Renders ──
+  const drawerData = useMemo(() => {
+    if (!drawer) return null;
+    const provider = providers.find((p) => p.id === drawer.providerId);
+    const model = provider?.models.find((m) => m.id === drawer.modelId);
+    if (!provider || !model) return null;
+    return { provider, model };
+  }, [drawer, providers]);
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      <div className={`models-shell ${className ?? ''}`}>
+        <div className="page" style={{ color: 'var(--m-text-muted)' }}>
+          Loading…
+        </div>
       </div>
     );
   }
 
-  const getDefaultForType = (type: ModelCapability) => {
-    if (type === 'completion') return defaultModel;
-    if (type === 'tts') return defaultTtsModel;
-    if (type === 'stt') return defaultSttModel;
-    // Image generation is per-request — no workspace-default model setting yet.
-    return '';
-  };
-
-  // Render a model table for a capability section
-  const renderModelTable = (
-    section: 'completion' | 'voice' | 'image',
-    title: string,
-    groups: Array<{ providerId: string; providerLabel: string; models: ModelRow[] }>,
-    headerAction?: React.ReactNode,
-  ) => {
-    const capTypes =
-      section === 'completion' ? ['completion']
-      : section === 'voice' ? ['tts', 'stt']
-      : ['image'];
-    const filtered = groups
-      .map(g => ({ ...g, models: g.models.filter(m => capTypes.includes(m.type)) }))
-      .filter(g => g.models.length > 0);
-
-    if (filtered.length === 0) return null;
-
-    const isCompletion = section === 'completion';
-    // Image models render in the same "non-completion" branch as voice models
-    // (single Cost column instead of context/cost/cached), but with their own
-    // pricing formatter and no voice-preview affordance.
-    const defaultAddCap: ModelCapability =
-      section === 'completion' ? 'completion'
-      : section === 'image' ? 'image'
-      : 'tts';
-    const configuredGroups = filtered.filter(g => g.models.some(m => m.providerConfigured));
-    const unconfiguredGroups = filtered.filter(g => !g.models.some(m => m.providerConfigured));
-
-    const renderTableHeader = () => isCompletion ? (
-      <div className="grid grid-cols-[1fr_70px_120px_70px_36px] gap-3 px-6 py-2.5 border-b border-border/40 bg-muted/30">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Model</span>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Context</span>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Cost / 1M</span>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Cached</span>
-        <span />
-      </div>
-    ) : (
-      <div className="grid grid-cols-[1fr_70px_130px_36px] gap-3 px-6 py-2.5 border-b border-border/40 bg-muted/30">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Model</span>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Type</span>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Cost</span>
-        <span />
-      </div>
-    );
-
-    const renderModelRows = (models: ModelRow[]) => models.map((model) => {
-      const fullId = `${model.providerId}/${model.id}`;
-      const isDefault = getDefaultForType(model.type) === fullId;
-      return isCompletion ? (
-        <div key={`${model.providerId}-${model.id}`}
-          className={`group grid grid-cols-[1fr_70px_120px_70px_36px] gap-3 items-start pl-10 pr-6 py-2.5 border-b border-border/10 last:border-b-0 transition ${model.providerConfigured ? 'hover:bg-muted/20' : 'opacity-40'}`}>
-          <div className="flex flex-col gap-0.5 min-w-0">
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="text-sm truncate text-muted-foreground">{model.name}</span>
-              {model.isCustom && <span className="text-[9px] text-muted-foreground/40 bg-muted/40 px-1 py-0.5 rounded shrink-0">custom</span>}
-              {model.isCustom && <button type="button" onClick={() => handleRemoveCustomModel(model.providerId, model.id)} className="text-muted-foreground/40 hover:text-destructive transition p-0.5 shrink-0" title="Remove"><X className="h-3.5 w-3.5" /></button>}
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="text-[11px] font-mono text-muted-foreground/40 truncate">{model.providerId}/{model.id}</span>
-              <button type="button" onClick={() => handleCopyId(fullId)} className="text-muted-foreground/30 hover:text-muted-foreground transition shrink-0" title="Copy model ID">
-                {copiedId === fullId ? <Check className="h-3 w-3 text-emerald-500" /> : <Copy className="h-3 w-3" />}
-              </button>
-            </div>
-          </div>
-          <div className="text-right">{model.contextWindow ? <span className="text-xs font-mono text-muted-foreground/60">{formatContextWindow(model.contextWindow)}</span> : <span className="text-xs text-muted-foreground/20">&mdash;</span>}</div>
-          <div className="text-right">{model.pricing?.type === 'completion' ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.input.toFixed(2)} / ${model.pricing.output.toFixed(2)}</span> : <span className="text-xs text-muted-foreground/20">&mdash;</span>}</div>
-          <div className="text-right">{model.pricing?.type === 'completion' && model.pricing.cached_input != null ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.cached_input.toFixed(2)}</span> : <span className="text-xs text-muted-foreground/20">&mdash;</span>}</div>
-          <div className="flex justify-end"><button type="button" onClick={() => model.providerConfigured && handleSetDefault(model.type, fullId)} disabled={saving || !model.providerConfigured} className={`p-1 rounded transition ${isDefault ? 'text-primary' : model.providerConfigured ? 'text-muted-foreground/40 hover:text-primary' : 'opacity-0'}`} title={isDefault ? 'Default' : 'Set as default'}><Star className={`h-4 w-4 ${isDefault ? 'fill-primary' : ''}`} /></button></div>
-        </div>
-      ) : (
-        <div key={`${model.providerId}-${model.type}-${model.id}`}
-          className={`group grid grid-cols-[1fr_70px_130px_36px] gap-3 items-start pl-10 pr-6 py-2.5 border-b border-border/10 last:border-b-0 transition ${model.providerConfigured ? 'hover:bg-muted/20' : 'opacity-40'}`}>
-          <button
-            type="button"
-            disabled={!model.providerConfigured || !model.voices?.length}
-            onClick={() => model.type === 'tts' && model.voices?.length && openVoiceDialog(model.providerId, model.id)}
-            className={`flex flex-col gap-0.5 min-w-0 text-left ${model.type === 'tts' && model.voices?.length && model.providerConfigured ? 'cursor-pointer' : 'cursor-default'}`}
-            title={model.type === 'tts' && model.voices?.length ? `${model.voices.length} voices — click to preview` : undefined}
-          >
-            <div className="flex items-center gap-2 min-w-0">
-              <span className="text-sm truncate text-muted-foreground">{model.name}</span>
-              {model.type === 'tts' && model.voices?.length && <span className="text-[10px] text-muted-foreground/40 shrink-0">{model.voices.length} voices</span>}
-              {model.isCustom && <span className="text-[9px] text-muted-foreground/40 bg-muted/40 px-1 py-0.5 rounded shrink-0">custom</span>}
-              {model.isCustom && <button type="button" onClick={(e) => { e.stopPropagation(); handleRemoveCustomModel(model.providerId, model.id); }} className="text-muted-foreground/40 hover:text-destructive transition p-0.5 shrink-0" title="Remove"><X className="h-3.5 w-3.5" /></button>}
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="text-[11px] font-mono text-muted-foreground/40 truncate">{model.providerId}/{model.id}</span>
-              <button type="button" onClick={(e) => { e.stopPropagation(); handleCopyId(fullId); }} className="text-muted-foreground/30 hover:text-muted-foreground transition shrink-0" title="Copy model ID">
-                {copiedId === fullId ? <Check className="h-3 w-3 text-emerald-500" /> : <Copy className="h-3 w-3" />}
-              </button>
-            </div>
-          </button>
-          <div><CapabilityBadge type={model.type} /></div>
-          <div className="text-right">{
-            model.pricing?.type === 'tts'
-              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_1m_chars.toFixed(2)} / 1M chars</span>
-              : model.pricing?.type === 'stt'
-              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_minute.toFixed(3)} / min</span>
-              : model.pricing?.type === 'image'
-              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_image.toFixed(3)} / image</span>
-              : <span className="text-xs text-muted-foreground/20">&mdash;</span>
-          }</div>
-          <div className="flex justify-end">{model.type === 'image' ? null : <button type="button" onClick={() => model.providerConfigured && handleSetDefault(model.type, fullId)} disabled={saving || !model.providerConfigured} className={`p-1 rounded transition ${isDefault ? 'text-primary' : model.providerConfigured ? 'text-muted-foreground/40 hover:text-primary' : 'opacity-0'}`} title={isDefault ? 'Default' : 'Set as default'}><Star className={`h-4 w-4 ${isDefault ? 'fill-primary' : ''}`} /></button>}</div>
-        </div>
-      );
-    });
-
+  if (error) {
     return (
-      <div className="space-y-0">
-        {(title || headerAction) && (
-          <div className="flex items-center justify-between mb-2">
-            {title && <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">{title}</p>}
-            <div className="flex-1" />
-            {headerAction}
-          </div>
-        )}
-        <div className="rounded-xl border border-border/70 bg-card shadow-sm overflow-hidden">
-          {renderTableHeader()}
-          {filtered.map((group) => {
-            const isConfigured = group.models.some(m => m.providerConfigured);
-            return (
-              <details key={group.providerId} open={isConfigured || undefined}>
-                <summary className="flex items-center gap-3 px-6 py-2.5 bg-muted/20 cursor-pointer hover:bg-muted/30 transition select-none list-none [&::-webkit-details-marker]:hidden">
-                  <ChevronDown className="h-4 w-4 text-muted-foreground/50 transition-transform [[open]>&]:rotate-180 shrink-0" />
-                  <span className={`text-[11px] font-semibold uppercase tracking-[0.15em] shrink-0 ${isConfigured ? 'text-muted-foreground/70' : 'text-muted-foreground/50'}`}>{group.providerLabel}</span>
-                  <span className="text-[11px] text-muted-foreground/40">{group.models.length} model{group.models.length !== 1 ? 's' : ''}</span>
-                  <div className="flex-1" />
-                  <button type="button" onClick={(e) => {
-                    e.preventDefault();
-                    const key = `${group.providerId}:${defaultAddCap}`;
-                    setAddingModelKey(addingModelKey === key ? null : key);
-                    setNewModelId('');
-                  }} className="text-muted-foreground/50 hover:text-foreground transition p-1 shrink-0" title="Add model">
-                    <Plus className="h-4 w-4" />
-                  </button>
-                  <button type="button" onClick={(e) => { e.preventDefault(); setAutoExpandProvider(group.providerId); onTabChange?.('providers'); }}
-                    className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground/60 hover:text-foreground transition shrink-0" title="Configure provider">
-                    {isConfigured ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Wrench className="h-3.5 w-3.5" />}
-                    Configure
-                  </button>
-                </summary>
-                <div className={isConfigured ? '' : 'opacity-50'}>
-                  {renderModelRows(group.models)}
-                  {addingModelKey?.startsWith(`${group.providerId}:`) && capTypes.includes(addingModelKey.split(':')[1] || '') && (
-                    <div className="flex items-center gap-2 pl-10 pr-6 py-1.5 bg-muted/10 border-t border-border/20">
-                      <input
-                        type="text"
-                        value={newModelId}
-                        onChange={(e) => setNewModelId(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleAddModel(group.providerId, (addingModelKey?.split(':')[1] || defaultAddCap) as ModelCapability);
-                          if (e.key === 'Escape') { setAddingModelKey(null); setNewModelId(''); }
-                        }}
-                        placeholder="Model ID (e.g. gpt-4o-mini)"
-                        autoFocus
-                        className="flex-1 rounded border border-border/50 bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none"
-                      />
-                      {section === 'voice' && (
-                        <select
-                          value={addingModelKey?.split(':')[1] || 'tts'}
-                          onChange={(e) => setAddingModelKey(`${group.providerId}:${e.target.value}`)}
-                          className="rounded border border-border/50 bg-background px-2 py-1 text-xs text-foreground"
-                        >
-                          <option value="tts">TTS</option>
-                          <option value="stt">STT</option>
-                        </select>
-                      )}
-                      <button type="button" onClick={() => handleAddModel(group.providerId, (addingModelKey?.split(':')[1] || defaultAddCap) as ModelCapability)}
-                        disabled={!newModelId.trim()} className="text-xs text-primary hover:text-primary/80 disabled:opacity-30">Add</button>
-                      <button type="button" onClick={() => { setAddingModelKey(null); setNewModelId(''); }}
-                        className="text-muted-foreground/40 hover:text-foreground"><X className="h-3 w-3" /></button>
-                    </div>
-                  )}
-                </div>
-              </details>
-            );
-          })}
-        </div>
-      </div>
-    );
-  };
-
-  // Render a provider card for the Providers tab
-  const renderProviderCard = (provider: ModelProviderDefinition) => {
-    const configured = isProviderConfigured(provider);
-    const isExpanded = expandedProviders.has(provider.id);
-    const capabilities = getProviderCapabilities(provider);
-
-    return (
-      <div key={provider.id} className="rounded-xl border border-border/70 bg-card shadow-sm overflow-hidden">
-        {/* Header */}
-        <button
-          type="button"
-          onClick={() => toggleProvider(provider.id)}
-          className="flex w-full items-center justify-between px-6 py-4 text-left hover:bg-muted/30 transition"
-        >
-          <div className="flex items-center gap-3">
-            <div>
-              <h3 className="text-sm font-semibold text-foreground">{provider.label}</h3>
-              {!isExpanded && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {configured ? 'Configured' : 'Not configured'}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center gap-1">
-              {provider.is_custom && (
-                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-amber-500/10 text-amber-500">Custom</span>
-              )}
-              {capabilities.map((cap) => (
-                <CapabilityBadge key={cap} type={cap} />
-              ))}
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {provider.is_custom && (
-              <span
-                role="button"
-                onClick={(e) => { e.stopPropagation(); handleRemoveCustomProvider(provider.id); }}
-                className="text-muted-foreground/40 hover:text-destructive transition p-1"
-                title="Remove provider"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </span>
-            )}
-            {configured && (
-              <div className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-500 shrink-0">
-                <Check className="h-3.5 w-3.5" />
-              </div>
-            )}
-            <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
-          </div>
-        </button>
-
-        {/* Expanded body */}
-        {isExpanded && <>
-          {/* Secret key fields */}
-          {provider.keys.length > 0 && (() => {
-            const hasUnsaved = provider.keys.some((k) => !getSecret(k.key) && fieldValues[k.key]?.trim());
-            return (
-              <div className="px-6 py-4 space-y-3">
-                {provider.keys.map((keyDef) => {
-                  const isSensitive = keyDef.sensitive !== false;
-                  const existing = getSecret(keyDef.key);
-
-                  return (
-                    <div key={keyDef.key}>
-                      <div className="flex items-center justify-between mb-1.5">
-                        <label className="text-xs font-medium text-muted-foreground">
-                          {keyDef.label}
-                          {!keyDef.required && <span className="ml-1 text-muted-foreground/40">(optional)</span>}
-                        </label>
-                        {existing && (
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteField(existing.key)}
-                            className="text-muted-foreground/40 transition hover:text-destructive"
-                            title="Remove"
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </button>
-                        )}
-                      </div>
-                      {existing ? (
-                        <div className="rounded-lg border border-border/50 bg-muted/30 px-3 py-2 text-sm font-mono text-foreground">
-                          {isSensitive ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022' : existing.masked_value}
-                        </div>
-                      ) : (
-                        <input
-                          type={isSensitive ? 'password' : 'text'}
-                          value={fieldValues[keyDef.key] || ''}
-                          onChange={(e) =>
-                            setFieldValues((prev) => ({ ...prev, [keyDef.key]: e.target.value }))
-                          }
-                          placeholder={keyDef.placeholder}
-                          className="w-full rounded-lg border border-border/70 bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
-                        />
-                      )}
-                    </div>
-                  );
-                })}
-                {/* Provider-level test + save */}
-                <div className="flex items-center justify-between gap-3 pt-1">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <button
-                      type="button"
-                      onClick={() => handleTestProvider(provider.id)}
-                      disabled={testingProvider === provider.id}
-                      className="rounded-lg border border-border/70 px-3 py-2 text-sm font-medium text-foreground transition hover:bg-muted/40 disabled:opacity-50"
-                    >
-                      {testingProvider === provider.id ? 'Testing…' : 'Test connection'}
-                    </button>
-                    {testResults[provider.id] && (
-                      <span
-                        className={`truncate text-xs ${testResults[provider.id].ok ? 'text-emerald-500' : 'text-destructive'}`}
-                      >
-                        {testResults[provider.id].ok ? '✓ ' : '✗ '}
-                        {testResults[provider.id].detail}
-                      </span>
-                    )}
-                  </div>
-                  {hasUnsaved && (
-                    <button
-                      type="button"
-                      onClick={() => handleSaveProvider(provider.id, provider.keys)}
-                      disabled={savingField === '__provider__'}
-                      className="shrink-0 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
-                    >
-                      {savingField === '__provider__' ? 'Saving...' : 'Save'}
-                    </button>
-                  )}
-                </div>
-              </div>
-            );
-          })()}
-        </>}
-      </div>
-    );
-  };
-
-  return (
-    <div className={`space-y-6 ${className ?? ''}`}>
-      {error && (
-        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      <div className={`models-shell ${className ?? ''}`}>
+        <div className="page" style={{ color: '#FDA4AF' }}>
           {error}
         </div>
-      )}
-      {saveSuccess && (
-        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600">
-          Settings saved.
-        </div>
-      )}
-
-      {/* Tab Bar */}
-      <div className="flex gap-1 rounded-lg bg-muted/50 p-1">
-        <button
-          type="button"
-          onClick={() => setActiveTab('models')}
-          className={`flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition ${
-            activeTab === 'models'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <Layers className="h-3.5 w-3.5" />
-          Models
-        </button>
-        <button
-          type="button"
-          onClick={() => setActiveTab('providers')}
-          className={`flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition ${
-            activeTab === 'providers'
-              ? 'bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <Settings className="h-3.5 w-3.5" />
-          Providers
-        </button>
       </div>
-
-      {/* Providers Tab */}
-      {activeTab === 'providers' && (<>
-        {[...providers].sort((a, b) => {
-          const aConfigured = isProviderConfigured(a) ? 0 : 1;
-          const bConfigured = isProviderConfigured(b) ? 0 : 1;
-          return aConfigured - bConfigured;
-        }).map((provider) => renderProviderCard(provider))}
-
-        {/* Add custom provider */}
-        <div className="rounded-xl border border-dashed border-border/70 bg-card/50 shadow-sm overflow-hidden">
-          {showAddProvider ? (
-            <div className="px-6 py-4 space-y-3">
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold text-foreground">Add Custom Provider</h3>
-                <button type="button" onClick={() => setShowAddProvider(false)} className="text-muted-foreground hover:text-foreground">
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-              <p className="text-xs text-muted-foreground">OpenAI-compatible endpoint (vLLM, LiteLLM, LangDB, Ollama, etc).</p>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground mb-1 block">Provider Name</label>
-                <input type="text" value={newProviderName} onChange={(e) => setNewProviderName(e.target.value)} placeholder="e.g. LangDB, My Ollama, Company LLM" className="w-full rounded-lg border border-border/70 bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
-              </div>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground mb-1 block">API URL</label>
-                <input type="text" value={newProviderUrl} onChange={(e) => setNewProviderUrl(e.target.value)} placeholder="https://api.example.com/v1" className="w-full rounded-lg border border-border/70 bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
-              </div>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground mb-1 block">API Key</label>
-                <input type="password" value={newProviderKey} onChange={(e) => setNewProviderKey(e.target.value)} placeholder="sk-..." className="w-full rounded-lg border border-border/70 bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
-              </div>
-              <div>
-                <label className="text-xs font-medium text-muted-foreground mb-1 block">Project ID <span className="text-muted-foreground/40">(optional)</span></label>
-                <input type="text" value={newProviderProjectId} onChange={(e) => setNewProviderProjectId(e.target.value)} placeholder="project-123" className="w-full rounded-lg border border-border/70 bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" />
-              </div>
-              <button type="button" onClick={handleAddCustomProvider} disabled={!newProviderName.trim() || !newProviderUrl.trim() || !newProviderKey.trim() || saving} className="w-full rounded-lg bg-primary py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50">
-                {saving ? 'Adding...' : 'Add Provider'}
-              </button>
-            </div>
-          ) : (
-            <button type="button" onClick={() => setShowAddProvider(true)} className="flex w-full items-center justify-center gap-2 px-6 py-4 text-sm text-muted-foreground transition hover:text-foreground">
-              <Plus className="h-4 w-4" />
-              Add Custom Provider
-            </button>
-          )}
-        </div>
-      </>)}
-
-      {/* Models Tab */}
-      {activeTab === 'models' && (<>
-        {/* Defaults */}
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground mb-2">Default Models</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {([
-            { label: 'Completion', type: 'completion' as ModelCapability, value: defaultModel },
-            { label: 'Text to Speech', type: 'tts' as ModelCapability, value: defaultTtsModel },
-            { label: 'Speech to Text', type: 'stt' as ModelCapability, value: defaultSttModel },
-          ]).map((card) => (
-            <button
-              key={card.type}
-              type="button"
-              onClick={() => {
-                setSelectorDialogCapability(card.type);
-                setSelectorDialogOpen(true);
-              }}
-              className="rounded-xl border border-border/70 bg-card px-4 py-3 shadow-sm text-left hover:bg-muted/30 transition group"
-            >
-              <div className="flex items-center gap-2 mb-1">
-                <CapabilityBadge type={card.type} />
-                <span className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">{card.label}</span>
-              </div>
-              <p className="text-sm font-mono text-foreground truncate">
-                {card.value || <span className="text-muted-foreground italic font-sans">Not set</span>}
-              </p>
-            </button>
-          ))}
-        </div>
-
-        {/* Completion Models */}
-        {renderModelTable('completion', 'Completion Models', groupedModels)}
-
-        {/* Voice Models (TTS + STT) */}
-        {renderModelTable('voice', 'Voice Models', groupedModels)}
-
-        {/* Image Models */}
-        {renderModelTable('image', 'Image Models', groupedModels)}
-
-        {/* Add custom provider link */}
-        <button
-          type="button"
-          onClick={() => {
-            setShowAddProvider(true);
-            onTabChange?.('providers');
-          }}
-          className="flex items-center gap-2 text-xs text-muted-foreground/60 hover:text-foreground transition"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          Add Custom Provider
-        </button>
-      </>)}
-
-      {/* Model Selector Dialog */}
-      {selectorDialogOpen && (
-        <ModelSelectorDialog
-          open={selectorDialogOpen}
-          onClose={() => setSelectorDialogOpen(false)}
-          capability={selectorDialogCapability}
-          models={allModels}
-          onSelect={async (providerId, modelId) => {
-            const fullId = `${providerId}/${modelId}`;
-            await handleSetDefault(selectorDialogCapability, fullId);
-            setSelectorDialogOpen(false);
-          }}
-        />
-      )}
-
-      {/* Voice Preview Dialog */}
-      {voiceDialogOpen && homeClient && (
-        <VoicePreviewDialog
-          open={voiceDialogOpen}
-          onClose={() => setVoiceDialogOpen(false)}
-          providers={providers}
-          isProviderConfigured={isProviderConfigured}
-          homeClient={homeClient}
-          onOpenProviders={() => setActiveTab('providers')}
-          initialModelId={voiceDialogModelId}
-          initialProviderId={voiceDialogProviderId}
-        />
-      )}
-    </div>
-  );
-}
-
-// ---------- ModelSelectorDialog ----------
-
-interface ModelRow {
-  id: string;
-  name: string;
-  providerId: string;
-  providerLabel: string;
-  type: ModelCapability;
-  isCustom: boolean;
-  providerConfigured: boolean;
-  contextWindow?: number;
-  pricing?: ModelPricing;
-  voices?: TtsVoiceInfo[];
-}
-
-interface ModelSelectorDialogProps {
-  open: boolean;
-  onClose: () => void;
-  capability: ModelCapability;
-  models: ModelRow[];
-  onSelect: (providerId: string, modelId: string) => void;
-}
-
-const capabilityTitle: Record<ModelCapability, string> = {
-  completion: 'Select Default Completion Model',
-  tts: 'Select Default Text to Speech Model',
-  stt: 'Select Default Speech to Text Model',
-  image: 'Select Image Model',
-};
-
-function ModelSelectorDialog({ open, onClose, capability, models, onSelect }: ModelSelectorDialogProps) {
-  if (!open) return null;
-
-  const filtered = models.filter((m) => m.type === capability);
-
-  // Group by provider
-  const groups: Array<{ providerId: string; providerLabel: string; models: ModelRow[] }> = [];
-  const map = new Map<string, ModelRow[]>();
-  const order: string[] = [];
-  for (const m of filtered) {
-    if (!map.has(m.providerId)) {
-      map.set(m.providerId, []);
-      order.push(m.providerId);
-    }
-    map.get(m.providerId)!.push(m);
-  }
-  for (const pid of order) {
-    const ms = map.get(pid)!;
-    groups.push({ providerId: pid, providerLabel: ms[0].providerLabel, models: ms });
+    );
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-2xl max-h-[80vh] rounded-xl border border-border bg-card shadow-xl flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border/60">
-          <h2 className="text-base font-semibold text-foreground">{capabilityTitle[capability]}</h2>
-          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground transition">
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* Table */}
-        <div className="flex-1 overflow-y-auto">
-          {/* Table header */}
-          <div className="grid grid-cols-[1fr_70px_110px_70px] gap-2 px-6 py-2 border-b border-border/40 bg-muted/30 sticky top-0">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Model</span>
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Context</span>
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Cost / 1M</span>
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground text-right">Cached</span>
+    <div className={`models-shell ${className ?? ''}`}>
+      <div className="page">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 20 }}>
+          <div className="subtabs">
+            <button
+              className={`subtab ${activeTab === 'models' && !playground ? 'active' : ''}`}
+              onClick={() => {
+                setPlayground(null);
+                setActiveTab('models');
+              }}
+            >
+              <Layers size={14} /> Models
+            </button>
+            <button
+              className={`subtab ${activeTab === 'providers' && !playground ? 'active' : ''}`}
+              onClick={() => {
+                setPlayground(null);
+                setActiveTab('providers');
+              }}
+            >
+              <SettingsIcon size={14} /> Providers
+              <span
+                style={{
+                  fontFamily: 'var(--m-font-mono)',
+                  fontSize: 10.5,
+                  color: configuredProviders.size ? '#6EE7B7' : 'var(--m-text-faint)',
+                  background: 'rgba(255,255,255,.04)',
+                  padding: '1px 5px',
+                  borderRadius: 4,
+                }}
+              >
+                {configuredProviders.size}/{providers.length}
+              </span>
+            </button>
           </div>
 
-          {groups.length === 0 && (
-            <div className="px-6 py-8 text-center">
-              <Layers className="h-8 w-8 text-muted-foreground/30 mx-auto mb-3" />
-              <p className="text-sm text-muted-foreground">No models available for this type.</p>
+          <span style={{ flex: 1 }} />
+
+          {!playground && (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={() => setPlayground({ capability: 'image' })}
+              >
+                <Beaker size={13} /> Image playground
+              </button>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={() => setPlayground({ capability: 'tts' })}
+              >
+                <Beaker size={13} /> Voice playground
+              </button>
             </div>
           )}
-
-          {groups.map((group) => (
-            <div key={group.providerId}>
-              <div className="flex items-center gap-3 px-6 py-2 bg-muted/20">
-                <div className="h-px flex-1 bg-border/50" />
-                <span className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground/70 shrink-0">
-                  {group.providerLabel}
-                </span>
-                <div className="h-px flex-1 bg-border/50" />
-              </div>
-              {group.models.map((model) => {
-                const configured = model.providerConfigured;
-                return (
-                  <button
-                    key={`${model.providerId}-${model.id}`}
-                    type="button"
-                    disabled={!configured}
-                    onClick={() => configured && onSelect(model.providerId, model.id)}
-                    className={`w-full grid grid-cols-[1fr_70px_110px_70px] gap-2 items-center px-6 py-2.5 border-b border-border/20 last:border-b-0 text-left transition ${
-                      configured
-                        ? 'hover:bg-primary/5 cursor-pointer'
-                        : 'opacity-40 cursor-not-allowed'
-                    }`}
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className={`text-sm truncate ${model.isCustom ? 'font-mono' : ''} text-foreground`}>
-                        {model.name}
-                      </span>
-                      {model.isCustom && (
-                        <span className="text-[10px] text-muted-foreground/50 bg-muted/50 px-1.5 py-0.5 rounded shrink-0">custom</span>
-                      )}
-                    </div>
-                    <div className="text-right">
-                      {capability === 'completion' && model.contextWindow ? (
-                        <span className="text-xs font-mono text-muted-foreground">
-                          {formatContextWindow(model.contextWindow)}
-                        </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground/30">&mdash;</span>
-                      )}
-                    </div>
-                    <div className="text-right">
-                      {model.pricing?.type === 'completion' ? (
-                        <span className="text-xs font-mono text-muted-foreground">
-                          ${model.pricing.input.toFixed(2)} / ${model.pricing.output.toFixed(2)}
-                        </span>
-                      ) : model.pricing?.type === 'tts' ? (
-                        <span className="text-xs font-mono text-muted-foreground">
-                          ${model.pricing.per_1m_chars.toFixed(2)} / 1M chars
-                        </span>
-                      ) : model.pricing?.type === 'stt' ? (
-                        <span className="text-xs font-mono text-muted-foreground">
-                          ${model.pricing.per_minute.toFixed(3)} / min
-                        </span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground/30">&mdash;</span>
-                      )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          ))}
         </div>
+
+        {playground?.capability === 'image' && homeClient && (
+          <ImagePlayground
+            homeClient={homeClient}
+            providers={providers}
+            configured={configuredProviders}
+            initialProviderId={playground.providerId}
+            initialModelId={playground.modelId}
+            onBack={() => setPlayground(null)}
+          />
+        )}
+        {playground?.capability === 'tts' && homeClient && (
+          <VoicePlayground
+            homeClient={homeClient}
+            providers={providers}
+            configured={configuredProviders}
+            initialProviderId={playground.providerId}
+            initialModelId={playground.modelId}
+            onBack={() => setPlayground(null)}
+          />
+        )}
+        {!playground && activeTab === 'models' && (
+          <CatalogTab
+            providers={providers}
+            secrets={secrets}
+            defaults={defaults}
+            favorites={favorites}
+            onToggleFavorite={toggleFavorite}
+            onOpenModel={handleOpenModel}
+            onOpenPlayground={handleOpenPlayground}
+            onConfigureProvider={handleConfigureProvider}
+            onChangeDefault={handleChangeDefault}
+          />
+        )}
+        {!playground && activeTab === 'providers' && (
+          <ProvidersTab
+            providers={providers}
+            secrets={secrets}
+            focusProviderId={focusProviderId}
+            onFocusProvider={setFocusProviderId}
+            onSaveKey={handleSaveKey}
+            onDeleteKey={handleDeleteKey}
+            onTestProvider={handleTestProvider}
+          />
+        )}
       </div>
+
+      {drawerData && (
+        <ModelDetailDrawer
+          provider={drawerData.provider}
+          model={drawerData.model}
+          configured={configuredProviders.has(drawerData.provider.id)}
+          isDefault={defaults[drawerData.model.capability] === `${drawerData.provider.id}/${drawerData.model.id}`}
+          isStarred={favorites.has(`${drawerData.provider.id}/${drawerData.model.id}`)}
+          onClose={() => setDrawer(null)}
+          onSetDefault={() =>
+            handleSetDefaultForModel(
+              drawerData.model.capability,
+              `${drawerData.provider.id}/${drawerData.model.id}`,
+            )
+          }
+          onToggleStar={() =>
+            toggleFavorite(`${drawerData.provider.id}/${drawerData.model.id}`)
+          }
+          onOpenPlayground={() => {
+            const cap = drawerData.model.capability;
+            handleOpenPlayground(cap, drawerData.provider.id, drawerData.model.id);
+            setDrawer(null);
+          }}
+          onConfigureProvider={() => {
+            setDrawer(null);
+            handleConfigureProvider(drawerData.provider.id);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/home/src/components/AgentSettingsView.tsx
+++ b/packages/home/src/components/AgentSettingsView.tsx
@@ -19,11 +19,13 @@ function CapabilityBadge({ type }: { type: ModelCapability }) {
     completion: 'bg-blue-500/10 text-blue-500',
     tts: 'bg-emerald-500/10 text-emerald-500',
     stt: 'bg-purple-500/10 text-purple-500',
+    image: 'bg-amber-500/10 text-amber-500',
   };
   const labels: Record<ModelCapability, string> = {
     completion: 'Completion',
     tts: 'TTS',
     stt: 'STT',
+    image: 'Image',
   };
   return (
     <span className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium ${styles[type]}`}>
@@ -479,17 +481,22 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
   const getDefaultForType = (type: ModelCapability) => {
     if (type === 'completion') return defaultModel;
     if (type === 'tts') return defaultTtsModel;
-    return defaultSttModel;
+    if (type === 'stt') return defaultSttModel;
+    // Image generation is per-request — no workspace-default model setting yet.
+    return '';
   };
 
   // Render a model table for a capability section
   const renderModelTable = (
-    section: 'completion' | 'voice',
+    section: 'completion' | 'voice' | 'image',
     title: string,
     groups: Array<{ providerId: string; providerLabel: string; models: ModelRow[] }>,
     headerAction?: React.ReactNode,
   ) => {
-    const capTypes = section === 'completion' ? ['completion'] : ['tts', 'stt'];
+    const capTypes =
+      section === 'completion' ? ['completion']
+      : section === 'voice' ? ['tts', 'stt']
+      : ['image'];
     const filtered = groups
       .map(g => ({ ...g, models: g.models.filter(m => capTypes.includes(m.type)) }))
       .filter(g => g.models.length > 0);
@@ -497,6 +504,13 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
     if (filtered.length === 0) return null;
 
     const isCompletion = section === 'completion';
+    // Image models render in the same "non-completion" branch as voice models
+    // (single Cost column instead of context/cost/cached), but with their own
+    // pricing formatter and no voice-preview affordance.
+    const defaultAddCap: ModelCapability =
+      section === 'completion' ? 'completion'
+      : section === 'image' ? 'image'
+      : 'tts';
     const configuredGroups = filtered.filter(g => g.models.some(m => m.providerConfigured));
     const unconfiguredGroups = filtered.filter(g => !g.models.some(m => m.providerConfigured));
 
@@ -565,8 +579,16 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
             </div>
           </button>
           <div><CapabilityBadge type={model.type} /></div>
-          <div className="text-right">{model.pricing?.type === 'tts' ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_1m_chars.toFixed(2)} / 1M chars</span> : model.pricing?.type === 'stt' ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_minute.toFixed(3)} / min</span> : <span className="text-xs text-muted-foreground/20">&mdash;</span>}</div>
-          <div className="flex justify-end"><button type="button" onClick={() => model.providerConfigured && handleSetDefault(model.type, fullId)} disabled={saving || !model.providerConfigured} className={`p-1 rounded transition ${isDefault ? 'text-primary' : model.providerConfigured ? 'text-muted-foreground/40 hover:text-primary' : 'opacity-0'}`} title={isDefault ? 'Default' : 'Set as default'}><Star className={`h-4 w-4 ${isDefault ? 'fill-primary' : ''}`} /></button></div>
+          <div className="text-right">{
+            model.pricing?.type === 'tts'
+              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_1m_chars.toFixed(2)} / 1M chars</span>
+              : model.pricing?.type === 'stt'
+              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_minute.toFixed(3)} / min</span>
+              : model.pricing?.type === 'image'
+              ? <span className="text-xs font-mono text-muted-foreground/60">${model.pricing.per_image.toFixed(3)} / image</span>
+              : <span className="text-xs text-muted-foreground/20">&mdash;</span>
+          }</div>
+          <div className="flex justify-end">{model.type === 'image' ? null : <button type="button" onClick={() => model.providerConfigured && handleSetDefault(model.type, fullId)} disabled={saving || !model.providerConfigured} className={`p-1 rounded transition ${isDefault ? 'text-primary' : model.providerConfigured ? 'text-muted-foreground/40 hover:text-primary' : 'opacity-0'}`} title={isDefault ? 'Default' : 'Set as default'}><Star className={`h-4 w-4 ${isDefault ? 'fill-primary' : ''}`} /></button>}</div>
         </div>
       );
     });
@@ -593,7 +615,7 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
                   <div className="flex-1" />
                   <button type="button" onClick={(e) => {
                     e.preventDefault();
-                    const key = `${group.providerId}:${section === 'completion' ? 'completion' : 'tts'}`;
+                    const key = `${group.providerId}:${defaultAddCap}`;
                     setAddingModelKey(addingModelKey === key ? null : key);
                     setNewModelId('');
                   }} className="text-muted-foreground/50 hover:text-foreground transition p-1 shrink-0" title="Add model">
@@ -607,14 +629,14 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
                 </summary>
                 <div className={isConfigured ? '' : 'opacity-50'}>
                   {renderModelRows(group.models)}
-                  {addingModelKey === `${group.providerId}:${section === 'completion' ? 'completion' : 'tts'}` && (
+                  {addingModelKey?.startsWith(`${group.providerId}:`) && capTypes.includes(addingModelKey.split(':')[1] || '') && (
                     <div className="flex items-center gap-2 pl-10 pr-6 py-1.5 bg-muted/10 border-t border-border/20">
                       <input
                         type="text"
                         value={newModelId}
                         onChange={(e) => setNewModelId(e.target.value)}
                         onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleAddModel(group.providerId, section === 'completion' ? 'completion' : 'tts');
+                          if (e.key === 'Enter') handleAddModel(group.providerId, (addingModelKey?.split(':')[1] || defaultAddCap) as ModelCapability);
                           if (e.key === 'Escape') { setAddingModelKey(null); setNewModelId(''); }
                         }}
                         placeholder="Model ID (e.g. gpt-4o-mini)"
@@ -631,7 +653,7 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
                           <option value="stt">STT</option>
                         </select>
                       )}
-                      <button type="button" onClick={() => handleAddModel(group.providerId, (addingModelKey?.split(':')[1] || 'completion') as ModelCapability)}
+                      <button type="button" onClick={() => handleAddModel(group.providerId, (addingModelKey?.split(':')[1] || defaultAddCap) as ModelCapability)}
                         disabled={!newModelId.trim()} className="text-xs text-primary hover:text-primary/80 disabled:opacity-30">Add</button>
                       <button type="button" onClick={() => { setAddingModelKey(null); setNewModelId(''); }}
                         className="text-muted-foreground/40 hover:text-foreground"><X className="h-3 w-3" /></button>
@@ -909,6 +931,9 @@ export function AgentSettingsView({ className, activeTab: activeTabProp, onTabCh
         {/* Voice Models (TTS + STT) */}
         {renderModelTable('voice', 'Voice Models', groupedModels)}
 
+        {/* Image Models */}
+        {renderModelTable('image', 'Image Models', groupedModels)}
+
         {/* Add custom provider link */}
         <button
           type="button"
@@ -982,6 +1007,7 @@ const capabilityTitle: Record<ModelCapability, string> = {
   completion: 'Select Default Completion Model',
   tts: 'Select Default Text to Speech Model',
   stt: 'Select Default Speech to Text Model',
+  image: 'Select Image Model',
 };
 
 function ModelSelectorDialog({ open, onClose, capability, models, onSelect }: ModelSelectorDialogProps) {

--- a/packages/home/src/components/AgentSettingsView.tsx
+++ b/packages/home/src/components/AgentSettingsView.tsx
@@ -30,6 +30,7 @@ import type {
 import { CatalogTab } from './models/CatalogTab';
 import { ImagePlayground } from './models/ImagePlayground';
 import { ModelDetailDrawer } from './models/ModelDetailDrawer';
+import type { AddCustomProviderInput } from './models/ProvidersTab';
 import { ProvidersTab } from './models/ProvidersTab';
 import { VoicePlayground } from './models/VoicePlayground';
 
@@ -191,6 +192,32 @@ export function AgentSettingsView({
     await loadData();
   };
 
+  const handleAddCustomProvider = async (input: AddCustomProviderInput) => {
+    if (!homeClient) return;
+    // Convention: the backend's `from_provider_model_str` accepts any
+    // `custom_*` prefix and routes it to OpenAICompatible. We derive a
+    // stable id from the display name to avoid surprise collisions.
+    const slug = input.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 32);
+    const providerId = `custom_${slug || `provider_${Date.now()}`}`;
+    const apiKeyName = `${providerId.toUpperCase()}_API_KEY`;
+    await homeClient.upsertProvider({
+      provider_id: providerId,
+      secrets: { [apiKeyName]: input.apiKey },
+      config: {
+        id: providerId,
+        name: input.name,
+        base_url: input.baseUrl,
+        project_id: input.projectId ?? null,
+      },
+    });
+    await loadData();
+    setFocusProviderId(providerId);
+  };
+
   const handleTestProvider = async (providerId: string) => {
     if (!homeClient) return { ok: false, detail: 'No client' };
     try {
@@ -332,6 +359,7 @@ export function AgentSettingsView({
             onSaveKey={handleSaveKey}
             onDeleteKey={handleDeleteKey}
             onTestProvider={handleTestProvider}
+            onAddCustomProvider={handleAddCustomProvider}
           />
         )}
       </div>

--- a/packages/home/src/components/AgentSettingsView.tsx
+++ b/packages/home/src/components/AgentSettingsView.tsx
@@ -19,7 +19,8 @@
 import './models/models.css';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Beaker, Layers, Settings as SettingsIcon } from 'lucide-react';
+import { ArrowLeft, Beaker, Layers, Settings as SettingsIcon } from 'lucide-react';
+import { CAPABILITY_META } from './models/data';
 import { useDistriHomeClient } from '../provider/context';
 import type {
   CustomModelEntry,
@@ -263,57 +264,82 @@ export function AgentSettingsView({
   return (
     <div className={`models-shell ${className ?? ''}`}>
       <div className="page">
-        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 20 }}>
-          <div className="subtabs">
-            <button
-              className={`subtab ${activeTab === 'models' && !playground ? 'active' : ''}`}
-              onClick={() => {
-                setPlayground(null);
-                setActiveTab('models');
-              }}
-            >
-              <Layers size={14} /> Models
-            </button>
-            <button
-              className={`subtab ${activeTab === 'providers' && !playground ? 'active' : ''}`}
-              onClick={() => {
-                setPlayground(null);
-                setActiveTab('providers');
-              }}
-            >
-              <SettingsIcon size={14} /> Providers
-              <span
-                style={{
-                  fontFamily: 'var(--m-font-mono)',
-                  fontSize: 10.5,
-                  color: configuredProviders.size ? '#6EE7B7' : 'var(--m-text-faint)',
-                  background: 'rgba(255,255,255,.04)',
-                  padding: '1px 5px',
-                  borderRadius: 4,
+        <div className="toolbar-row">
+          {playground ? (
+            <>
+              <button className="subtab back" onClick={() => setPlayground(null)}>
+                <ArrowLeft size={13} /> Models
+              </button>
+              <span className="tb-sep" />
+              <div className="cap-switcher">
+                {(['tts', 'image'] as const).map((c) => {
+                  const active = playground.capability === c;
+                  return (
+                    <button
+                      key={c}
+                      className={`cap-switch ${active ? 'active' : ''}`}
+                      onClick={() => {
+                        const def = defaults[c];
+                        const [pid, mid] = (def || '').split('/');
+                        setPlayground({
+                          capability: c,
+                          providerId: pid || undefined,
+                          modelId: mid || undefined,
+                        });
+                      }}
+                    >
+                      {CAPABILITY_META[c].label}
+                    </button>
+                  );
+                })}
+              </div>
+              <span style={{ flex: 1 }} />
+            </>
+          ) : (
+            <>
+              <div className="subtabs">
+                <button
+                  className={`subtab ${activeTab === 'models' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('models')}
+                >
+                  <Layers size={14} /> Models
+                  <span className="subtab-count">
+                    {providers.reduce((n, p) => n + p.models.length, 0)}
+                  </span>
+                </button>
+                <button
+                  className={`subtab ${activeTab === 'providers' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('providers')}
+                >
+                  <SettingsIcon size={14} /> Providers
+                  <span
+                    className="subtab-count"
+                    style={{
+                      color: configuredProviders.size ? '#6EE7B7' : 'var(--m-text-faint)',
+                    }}
+                  >
+                    {configuredProviders.size}/{providers.length}
+                  </span>
+                </button>
+              </div>
+              <span style={{ flex: 1 }} />
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => {
+                  // Open Voice playground by default — Completion has no
+                  // playground component built yet; Voice + Image are wired.
+                  const def = defaults.tts;
+                  const [pid, mid] = (def || '').split('/');
+                  setPlayground({
+                    capability: 'tts',
+                    providerId: pid || undefined,
+                    modelId: mid || undefined,
+                  });
                 }}
               >
-                {configuredProviders.size}/{providers.length}
-              </span>
-            </button>
-          </div>
-
-          <span style={{ flex: 1 }} />
-
-          {!playground && (
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={() => setPlayground({ capability: 'image' })}
-              >
-                <Beaker size={13} /> Image playground
+                <Beaker size={13} /> Playground
               </button>
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={() => setPlayground({ capability: 'tts' })}
-              >
-                <Beaker size={13} /> Voice playground
-              </button>
-            </div>
+            </>
           )}
         </div>
 

--- a/packages/home/src/components/SettingsView.tsx
+++ b/packages/home/src/components/SettingsView.tsx
@@ -1,7 +1,7 @@
 import { ComponentType } from 'react';
 import { useDistriHomeNavigate } from '../provider/context';
 import { SecretsView } from './SecretsView';
-import { AgentSettingsView } from './AgentSettingsView';
+import { ModelsView } from './models/ModelsView';
 import { Settings as SettingsIcon, LockIcon, LucideIcon } from 'lucide-react';
 
 // Section type definition - exported for consumers to create custom sections
@@ -33,9 +33,9 @@ export interface SettingsViewProps {
   onSectionChange?: (section: string) => void;
 }
 
-// Wrapper for AgentSettingsView to match section component signature
+// Wrapper for ModelsView to match section component signature.
 function AgentSettingsSection({ className }: { className?: string }) {
-  return <AgentSettingsView className={className} />;
+  return <ModelsView className={className} />;
 }
 
 // Default sections - core distri-home sections only (no cloud-specific Account/API Keys)

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -543,36 +543,34 @@ function CatalogRowView({
         </>
       )}
 
-      <div style={{ textAlign: 'center' }}>
-        {isDefault ? (
-          <span
-            className="cap-pill"
-            style={{
-              background: 'rgba(34,174,195,.16)',
-              color: 'var(--m-brand-soft)',
-              borderColor: 'rgba(34,174,195,.32)',
-            }}
-          >
-            Default
-          </span>
-        ) : null}
-      </div>
-
-      <div className="row-actions" onClick={(e) => e.stopPropagation()}>
+      <div style={{ textAlign: 'center' }} onClick={(e) => e.stopPropagation()}>
+        {/* The Default column IS the toggle. Click flips this model on/off
+            as the workspace default for its capability. */}
         <button
           onClick={() => onSetDefault(row)}
           title={isDefault ? 'Clear default for this capability' : 'Set as default for this capability'}
           aria-pressed={isDefault}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '2px 4px',
+            borderRadius: 4,
+            color: isDefault ? 'var(--m-brand-soft)' : 'var(--m-text-faint)',
+          }}
         >
           {isDefault ? (
-            <CheckCircle2
-              size={15}
-              style={{ color: 'var(--m-brand-soft)', fill: 'currentColor' }}
-            />
+            <CheckCircle2 size={15} style={{ fill: 'currentColor' }} />
           ) : (
             <Circle size={15} />
           )}
+          {isDefault && (
+            <span style={{ fontSize: 11, fontWeight: 600 }}>Default</span>
+          )}
         </button>
+      </div>
+
+      <div className="row-actions" onClick={(e) => e.stopPropagation()}>
         <button className="play" onClick={() => onPlay(row)} title="Open in playground">
           <Play size={13} />
         </button>

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -15,7 +15,9 @@ import {
   ArrowRight,
   ArrowUp,
   Check,
+  CheckCircle2,
   ChevronRight,
+  Circle,
   Copy,
   Image as ImageIcon,
   Layers,
@@ -25,7 +27,6 @@ import {
   Search,
   Sparkles,
   Speaker,
-  Star,
   Wrench,
 } from 'lucide-react';
 import type {
@@ -46,12 +47,12 @@ interface CatalogTabProps {
     stt: string;
     image: string;
   };
-  favorites: Set<string>;
-  onToggleFavorite: (fullId: string) => void;
+  /** Toggle a model as the workspace default for its capability. Pass
+   *  the same `provider/model` id again to clear. */
+  onSetDefault: (capability: ModelCapability, fullId: string) => void;
   onOpenModel: (providerId: string, modelId: string) => void;
   onOpenPlayground: (capability: ModelCapability, providerId: string, modelId: string) => void;
   onConfigureProvider: (providerId: string) => void;
-  onChangeDefault: (capability: ModelCapability) => void;
 }
 
 interface CatalogRow {
@@ -69,12 +70,10 @@ export function CatalogTab({
   providers,
   secrets,
   defaults,
-  favorites,
-  onToggleFavorite,
+  onSetDefault,
   onOpenModel,
   onOpenPlayground,
   onConfigureProvider,
-  onChangeDefault,
 }: CatalogTabProps) {
   const [search, setSearch] = useState('');
   const [capFilter, setCapFilter] = useState<CapFilter>('all');
@@ -215,7 +214,16 @@ export function CatalogTab({
 
   return (
     <>
-      <DefaultStrip defaults={defaults} onChange={onChangeDefault} />
+      <DefaultStrip
+        defaults={defaults}
+        onChange={(capability) => {
+          // No-op for now: the default-card click navigates the user to
+          // the capability-filtered catalog so they can pick a model
+          // and toggle its default circle. We just switch the chip
+          // filter to make that flow obvious.
+          setCapFilter(capability);
+        }}
+      />
 
       <div className="toolbar">
         <CapChips active={capFilter} counts={counts} onChange={setCapFilter} />
@@ -287,8 +295,7 @@ export function CatalogTab({
                     row={row}
                     configured={isConfigured}
                     isDefault={def === fullId}
-                    isStarred={favorites.has(fullId)}
-                    onStar={onToggleFavorite}
+                    onSetDefault={(r) => onSetDefault(r.capability, `${r.providerId}/${r.modelId}`)}
                     onCopy={handleCopy}
                     copied={copiedId === fullId}
                     onClick={(r) => onOpenModel(r.providerId, r.modelId)}
@@ -450,8 +457,7 @@ function CatalogRowView({
   row,
   configured,
   isDefault,
-  isStarred,
-  onStar,
+  onSetDefault,
   onCopy,
   copied,
   onClick,
@@ -461,8 +467,7 @@ function CatalogRowView({
   row: CatalogRow;
   configured: boolean;
   isDefault: boolean;
-  isStarred: boolean;
-  onStar: (fullId: string) => void;
+  onSetDefault: (row: CatalogRow) => void;
   onCopy: (id: string) => void;
   copied: boolean;
   onClick: (row: CatalogRow) => void;
@@ -550,14 +555,23 @@ function CatalogRowView({
           >
             Default
           </span>
-        ) : isStarred ? (
-          <Star size={14} style={{ color: 'var(--m-brand-soft)', fill: 'currentColor' }} />
         ) : null}
       </div>
 
       <div className="row-actions" onClick={(e) => e.stopPropagation()}>
-        <button onClick={() => onStar(fullId)} title={isStarred ? 'Unstar' : 'Star'}>
-          <Star size={14} style={isStarred ? { fill: 'currentColor', color: 'var(--m-brand-soft)' } : undefined} />
+        <button
+          onClick={() => onSetDefault(row)}
+          title={isDefault ? 'Clear default for this capability' : 'Set as default for this capability'}
+          aria-pressed={isDefault}
+        >
+          {isDefault ? (
+            <CheckCircle2
+              size={15}
+              style={{ color: 'var(--m-brand-soft)', fill: 'currentColor' }}
+            />
+          ) : (
+            <Circle size={15} />
+          )}
         </button>
         <button className="play" onClick={() => onPlay(row)} title="Open in playground">
           <Play size={13} />

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -214,16 +214,7 @@ export function CatalogTab({
 
   return (
     <>
-      <DefaultStrip
-        defaults={defaults}
-        onChange={(capability) => {
-          // No-op for now: the default-card click navigates the user to
-          // the capability-filtered catalog so they can pick a model
-          // and toggle its default circle. We just switch the chip
-          // filter to make that flow obvious.
-          setCapFilter(capability);
-        }}
-      />
+      <DefaultStrip defaults={defaults} />
 
       <div className="toolbar">
         <CapChips active={capFilter} counts={counts} onChange={setCapFilter} />
@@ -324,13 +315,7 @@ function priceKey(m: Model): number {
   return 0;
 }
 
-function DefaultStrip({
-  defaults,
-  onChange,
-}: {
-  defaults: Record<ModelCapability, string>;
-  onChange: (capability: ModelCapability) => void;
-}) {
+function DefaultStrip({ defaults }: { defaults: Record<ModelCapability, string> }) {
   const caps: ModelCapability[] = ['completion', 'tts', 'stt', 'image'];
   return (
     <div className="defaults">
@@ -338,7 +323,7 @@ function DefaultStrip({
         const meta = CAPABILITY_META[cap];
         const val = defaults[cap];
         return (
-          <div key={cap} className="default-card" onClick={() => onChange(cap)}>
+          <div key={cap} className="default-card">
             <div className="row1">
               <CapPill type={cap} />
               <span className="cap-label">Default {meta.short.toLowerCase()}</span>
@@ -346,7 +331,6 @@ function DefaultStrip({
             <div className={`value ${val ? '' : 'empty'}`} title={val || undefined}>
               {val || 'Not set — pick a model'}
             </div>
-            <span className="change">Change ›</span>
           </div>
         );
       })}

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -1,0 +1,578 @@
+/**
+ * Catalog tab — dense, grouped-by-provider table with capability sub-tabs
+ * and per-capability default-model strip at the top.
+ *
+ * Wired to real `DistriHomeClient` data:
+ *   listProviders() → provider/model catalog
+ *   listSecrets()   → which providers are configured
+ *   getWorkspaceSettings() → default_model / default_tts_model /
+ *                            default_stt_model / default_image_model
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ArrowDown,
+  ArrowRight,
+  ArrowUp,
+  Check,
+  ChevronRight,
+  Copy,
+  Image as ImageIcon,
+  Layers,
+  Mic,
+  Play,
+  Plus,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+  Speaker,
+  Star,
+  Wrench,
+} from 'lucide-react';
+import type {
+  Model,
+  ModelCapability,
+  ModelProviderDefinition,
+  Secret,
+} from '../../DistriHomeClient';
+import { CAPABILITY_META, formatContext, providerMonogram } from './data';
+import { CapPill, PricingCell } from './primitives';
+
+interface CatalogTabProps {
+  providers: ModelProviderDefinition[];
+  secrets: Secret[];
+  defaults: {
+    completion: string;
+    tts: string;
+    stt: string;
+    image: string;
+  };
+  favorites: Set<string>;
+  onToggleFavorite: (fullId: string) => void;
+  onOpenModel: (providerId: string, modelId: string) => void;
+  onOpenPlayground: (capability: ModelCapability, providerId: string, modelId: string) => void;
+  onConfigureProvider: (providerId: string) => void;
+  onChangeDefault: (capability: ModelCapability) => void;
+}
+
+interface CatalogRow {
+  providerId: string;
+  providerLabel: string;
+  modelId: string;
+  capability: ModelCapability;
+  model: Model;
+}
+
+type SortKey = 'name' | 'context' | 'price';
+type CapFilter = 'all' | ModelCapability;
+
+export function CatalogTab({
+  providers,
+  secrets,
+  defaults,
+  favorites,
+  onToggleFavorite,
+  onOpenModel,
+  onOpenPlayground,
+  onConfigureProvider,
+  onChangeDefault,
+}: CatalogTabProps) {
+  const [search, setSearch] = useState('');
+  const [capFilter, setCapFilter] = useState<CapFilter>('all');
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({
+    key: 'context',
+    dir: 'desc',
+  });
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  // Configured = every required secret is present.
+  const configuredProviders = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of providers) {
+      const required = p.keys.filter((k) => k.required !== false);
+      const allPresent = required.every((k) => secrets.some((s) => s.key === k.key));
+      if (required.length > 0 && allPresent) set.add(p.id);
+    }
+    return set;
+  }, [providers, secrets]);
+
+  const [openProviders, setOpenProviders] = useState<Set<string>>(
+    () => new Set(providers.filter((p) => configuredProviders.has(p.id)).map((p) => p.id)),
+  );
+
+  // Flatten + count
+  const flatRows = useMemo<CatalogRow[]>(() => {
+    const out: CatalogRow[] = [];
+    for (const p of providers) {
+      for (const m of p.models) {
+        out.push({
+          providerId: p.id,
+          providerLabel: p.label,
+          modelId: m.id,
+          capability: m.capability,
+          model: m,
+        });
+      }
+    }
+    return out;
+  }, [providers]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: flatRows.length };
+    for (const r of flatRows) c[r.capability] = (c[r.capability] ?? 0) + 1;
+    return c;
+  }, [flatRows]);
+
+  const filtered = useMemo(() => {
+    let rows = flatRows;
+    if (capFilter !== 'all') rows = rows.filter((r) => r.capability === capFilter);
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      rows = rows.filter(
+        (r) =>
+          r.model.name.toLowerCase().includes(q) ||
+          r.modelId.toLowerCase().includes(q) ||
+          r.providerLabel.toLowerCase().includes(q),
+      );
+    }
+    return rows;
+  }, [flatRows, capFilter, search]);
+
+  // Group by provider; configured first, then catalog order.
+  const grouped = useMemo(() => {
+    const byProvider = new Map<string, CatalogRow[]>();
+    const order: string[] = [];
+    for (const r of filtered) {
+      if (!byProvider.has(r.providerId)) {
+        byProvider.set(r.providerId, []);
+        order.push(r.providerId);
+      }
+      byProvider.get(r.providerId)!.push(r);
+    }
+    order.sort((a, b) => {
+      const ac = configuredProviders.has(a) ? 0 : 1;
+      const bc = configuredProviders.has(b) ? 0 : 1;
+      if (ac !== bc) return ac - bc;
+      const ai = providers.findIndex((p) => p.id === a);
+      const bi = providers.findIndex((p) => p.id === b);
+      return ai - bi;
+    });
+    // Sort within each group.
+    for (const pid of order) {
+      const list = byProvider.get(pid)!;
+      list.sort((a, b) => {
+        const dir = sort.dir === 'asc' ? 1 : -1;
+        if (sort.key === 'name') return a.model.name.localeCompare(b.model.name) * dir;
+        if (sort.key === 'context') {
+          return ((a.model.context_window ?? 0) - (b.model.context_window ?? 0)) * dir;
+        }
+        if (sort.key === 'price') {
+          const pa = priceKey(a.model);
+          const pb = priceKey(b.model);
+          return (pa - pb) * dir;
+        }
+        return 0;
+      });
+    }
+    return order.map((pid) => ({ providerId: pid, models: byProvider.get(pid)! }));
+  }, [filtered, sort, providers, configuredProviders]);
+
+  // Column layout follows the capability filter (defaulting to the
+  // completion table for "all").
+  const columns: 'completion' | 'voice' | 'image' =
+    capFilter === 'image' ? 'image' : capFilter === 'tts' || capFilter === 'stt' ? 'voice' : 'completion';
+
+  const handleCopy = useCallback((id: string) => {
+    if (navigator.clipboard) navigator.clipboard.writeText(id).catch(() => {});
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 1200);
+  }, []);
+
+  const toggleProvider = (id: string) =>
+    setOpenProviders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const sortableHeader = (key: SortKey, label: string, opts?: { num?: boolean }) => {
+    const active = sort.key === key;
+    return (
+      <span
+        className={`sortable ${active ? 'active' : ''} ${opts?.num ? 'num' : ''}`}
+        onClick={() =>
+          setSort((prev) => ({
+            key,
+            dir: prev.key === key && prev.dir === 'desc' ? 'asc' : 'desc',
+          }))
+        }
+      >
+        {label}
+        {active && (sort.dir === 'desc' ? <ArrowDown size={11} /> : <ArrowUp size={11} />)}
+      </span>
+    );
+  };
+
+  return (
+    <>
+      <DefaultStrip defaults={defaults} onChange={onChangeDefault} />
+
+      <div className="toolbar">
+        <CapChips active={capFilter} counts={counts} onChange={setCapFilter} />
+        <span style={{ flex: 1 }} />
+        <div className="search">
+          <Search size={14} />
+          <input
+            placeholder="Search models, providers, IDs…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <span className="kbd">⌘K</span>
+        </div>
+        <button className="btn btn-secondary btn-sm">
+          <SlidersHorizontal size={13} /> Filter
+        </button>
+      </div>
+
+      <div className="cat-card">
+        <div className={`cat-head cat-cols-${columns}`}>
+          {sortableHeader('name', 'Model')}
+          <span style={{ textAlign: 'left' }}>Capability</span>
+          {columns === 'completion' && (
+            <>
+              {sortableHeader('context', 'Context', { num: true })}
+              {sortableHeader('price', 'Cost / 1M', { num: true })}
+              <span className="num">Cached</span>
+            </>
+          )}
+          {columns === 'voice' && (
+            <>
+              <span className="num">{capFilter === 'tts' ? 'Voices' : 'Languages'}</span>
+              {sortableHeader('price', 'Price', { num: true })}
+            </>
+          )}
+          {columns === 'image' && (
+            <>
+              <span className="num">Sizes</span>
+              {sortableHeader('price', 'Price', { num: true })}
+            </>
+          )}
+          <span style={{ textAlign: 'center' }}>Default</span>
+          <span style={{ textAlign: 'right' }}>Actions</span>
+        </div>
+
+        {grouped.length === 0 && (
+          <div style={{ padding: '48px 18px', textAlign: 'center', color: 'var(--m-text-muted)' }}>
+            No models match — try clearing your search or capability filter.
+          </div>
+        )}
+
+        {grouped.map((g) => {
+          const p = providers.find((x) => x.id === g.providerId);
+          if (!p) return null;
+          const isOpen = openProviders.has(g.providerId);
+          const isConfigured = configuredProviders.has(g.providerId);
+          return (
+            <ProviderGroupSection
+              key={g.providerId}
+              provider={p}
+              models={g.models}
+              open={isOpen}
+              configured={isConfigured}
+              onToggle={() => toggleProvider(g.providerId)}
+              onConfigure={() => onConfigureProvider(g.providerId)}
+              renderRow={(row) => {
+                const fullId = `${row.providerId}/${row.modelId}`;
+                const def = defaults[row.capability];
+                return (
+                  <CatalogRowView
+                    key={fullId}
+                    row={row}
+                    configured={isConfigured}
+                    isDefault={def === fullId}
+                    isStarred={favorites.has(fullId)}
+                    onStar={onToggleFavorite}
+                    onCopy={handleCopy}
+                    copied={copiedId === fullId}
+                    onClick={(r) => onOpenModel(r.providerId, r.modelId)}
+                    onPlay={(r) => onOpenPlayground(r.capability, r.providerId, r.modelId)}
+                    columns={columns}
+                  />
+                );
+              }}
+            />
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function priceKey(m: Model): number {
+  const p = m.pricing;
+  if (!p) return 0;
+  if (p.type === 'completion') return p.input ?? 0;
+  if (p.type === 'tts') return p.per_1m_chars ?? 0;
+  if (p.type === 'stt') return p.per_minute ?? 0;
+  if (p.type === 'image') return p.per_image ?? 0;
+  return 0;
+}
+
+function DefaultStrip({
+  defaults,
+  onChange,
+}: {
+  defaults: Record<ModelCapability, string>;
+  onChange: (capability: ModelCapability) => void;
+}) {
+  const caps: ModelCapability[] = ['completion', 'tts', 'stt', 'image'];
+  return (
+    <div className="defaults">
+      {caps.map((cap) => {
+        const meta = CAPABILITY_META[cap];
+        const val = defaults[cap];
+        return (
+          <div key={cap} className="default-card" onClick={() => onChange(cap)}>
+            <div className="row1">
+              <CapPill type={cap} />
+              <span className="cap-label">Default {meta.short.toLowerCase()}</span>
+            </div>
+            <div className={`value ${val ? '' : 'empty'}`} title={val || undefined}>
+              {val || 'Not set — pick a model'}
+            </div>
+            <span className="change">Change ›</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CapChips({
+  active,
+  counts,
+  onChange,
+}: {
+  active: CapFilter;
+  counts: Record<string, number>;
+  onChange: (next: CapFilter) => void;
+}) {
+  const items: { id: CapFilter; label: string; icon: React.ComponentType<{ size?: number }> }[] = [
+    { id: 'all', label: 'All models', icon: Layers },
+    { id: 'completion', label: 'Completion', icon: Sparkles },
+    { id: 'tts', label: 'Text to speech', icon: Speaker },
+    { id: 'stt', label: 'Speech to text', icon: Mic },
+    { id: 'image', label: 'Image', icon: ImageIcon },
+  ];
+  return (
+    <div className="cap-chips">
+      {items.map((it) => {
+        const Ic = it.icon;
+        return (
+          <button
+            key={it.id}
+            className={`cap-chip ${active === it.id ? 'active' : ''}`}
+            onClick={() => onChange(it.id)}
+          >
+            <Ic size={13} />
+            {it.label}
+            <span className="count">{counts[it.id] ?? 0}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProviderGroupSection({
+  provider,
+  models,
+  open,
+  configured,
+  onToggle,
+  onConfigure,
+  renderRow,
+}: {
+  provider: ModelProviderDefinition;
+  models: CatalogRow[];
+  open: boolean;
+  configured: boolean;
+  onToggle: () => void;
+  onConfigure: () => void;
+  renderRow: (row: CatalogRow) => React.ReactNode;
+}) {
+  return (
+    <>
+      <div className={`cat-provider ${open ? 'open' : ''}`} onClick={onToggle}>
+        <ChevronRight size={14} className="chev" />
+        <div className="name">
+          <span className="mono">{providerMonogram(provider.id)}</span>
+          <span>{provider.label}</span>
+          <span className="count">
+            · {models.length} {models.length === 1 ? 'model' : 'models'}
+          </span>
+        </div>
+        <span className={`status ${configured ? 'ok' : 'bad'}`}>
+          {configured ? (
+            <>
+              <span
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  background: '#34D399',
+                  boxShadow: '0 0 0 3px rgba(16,185,129,.16)',
+                }}
+              />
+              Configured
+            </>
+          ) : (
+            'Not configured'
+          )}
+        </span>
+        <button
+          className="quick"
+          onClick={(e) => {
+            e.stopPropagation();
+            onConfigure();
+          }}
+        >
+          <Wrench size={11} />
+          {configured ? 'Manage' : 'Configure'}
+        </button>
+        <span />
+      </div>
+      {open && models.map(renderRow)}
+    </>
+  );
+}
+
+function CatalogRowView({
+  row,
+  configured,
+  isDefault,
+  isStarred,
+  onStar,
+  onCopy,
+  copied,
+  onClick,
+  onPlay,
+  columns,
+}: {
+  row: CatalogRow;
+  configured: boolean;
+  isDefault: boolean;
+  isStarred: boolean;
+  onStar: (fullId: string) => void;
+  onCopy: (id: string) => void;
+  copied: boolean;
+  onClick: (row: CatalogRow) => void;
+  onPlay: (row: CatalogRow) => void;
+  columns: 'completion' | 'voice' | 'image';
+}) {
+  const fullId = `${row.providerId}/${row.modelId}`;
+  const meta = row.model;
+
+  return (
+    <div
+      className={`cat-row cat-cols-${columns} ${configured ? '' : 'disabled'}`}
+      onClick={() => onClick(row)}
+    >
+      <div className="model">
+        <span className="mono-pill">{providerMonogram(row.providerId)}</span>
+        <div>
+          <div className="name">
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {meta.name}
+            </span>
+          </div>
+          <div className="id" onClick={(e) => e.stopPropagation()}>
+            <span>{fullId}</span>
+            <button className="copy" onClick={() => onCopy(fullId)} title="Copy model ID">
+              {copied ? <Check size={11} /> : <Copy size={11} />}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <CapPill type={row.capability} />
+      </div>
+
+      {columns === 'completion' && (
+        <>
+          <div className="num">
+            <strong>{formatContext(meta.context_window)}</strong>
+          </div>
+          <div>
+            <PricingCell pricing={meta.pricing} />
+          </div>
+          <div>
+            <PricingCell pricing={meta.pricing} kind="cached" />
+          </div>
+        </>
+      )}
+      {columns === 'voice' && (
+        <>
+          <div className="num">
+            {row.capability === 'tts' && meta.voices?.length ? (
+              <span>
+                <strong>{meta.voices.length}</strong> <span className="em">voices</span>
+              </span>
+            ) : (
+              <span className="em">—</span>
+            )}
+          </div>
+          <div>
+            <PricingCell pricing={meta.pricing} />
+          </div>
+        </>
+      )}
+      {columns === 'image' && (
+        <>
+          <div className="num" style={{ fontSize: 11.5 }}>
+            {meta.formats?.length ? meta.formats.slice(0, 3).join(', ') : <span className="em">—</span>}
+          </div>
+          <div>
+            <PricingCell pricing={meta.pricing} />
+          </div>
+        </>
+      )}
+
+      <div style={{ textAlign: 'center' }}>
+        {isDefault ? (
+          <span
+            className="cap-pill"
+            style={{
+              background: 'rgba(34,174,195,.16)',
+              color: 'var(--m-brand-soft)',
+              borderColor: 'rgba(34,174,195,.32)',
+            }}
+          >
+            Default
+          </span>
+        ) : isStarred ? (
+          <Star size={14} style={{ color: 'var(--m-brand-soft)', fill: 'currentColor' }} />
+        ) : null}
+      </div>
+
+      <div className="row-actions" onClick={(e) => e.stopPropagation()}>
+        <button onClick={() => onStar(fullId)} title={isStarred ? 'Unstar' : 'Star'}>
+          <Star size={14} style={isStarred ? { fill: 'currentColor', color: 'var(--m-brand-soft)' } : undefined} />
+        </button>
+        <button className="play" onClick={() => onPlay(row)} title="Open in playground">
+          <Play size={13} />
+        </button>
+        <button onClick={() => onClick(row)} title="Details">
+          <ArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Unused but explicitly imported to keep tree-shaking aware of usage in JSX above.
+export { Plus };

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -23,7 +23,6 @@ import {
   Play,
   Plus,
   Search,
-  SlidersHorizontal,
   Sparkles,
   Speaker,
   Star,
@@ -79,8 +78,6 @@ export function CatalogTab({
 }: CatalogTabProps) {
   const [search, setSearch] = useState('');
   const [capFilter, setCapFilter] = useState<CapFilter>('all');
-  /** Show only models from providers whose required keys are saved. */
-  const [configuredOnly, setConfiguredOnly] = useState(false);
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({
     key: 'context',
     dir: 'desc',
@@ -128,7 +125,6 @@ export function CatalogTab({
   const filtered = useMemo(() => {
     let rows = flatRows;
     if (capFilter !== 'all') rows = rows.filter((r) => r.capability === capFilter);
-    if (configuredOnly) rows = rows.filter((r) => configuredProviders.has(r.providerId));
     if (search.trim()) {
       const q = search.toLowerCase();
       rows = rows.filter(
@@ -139,7 +135,7 @@ export function CatalogTab({
       );
     }
     return rows;
-  }, [flatRows, capFilter, search, configuredOnly, configuredProviders]);
+  }, [flatRows, capFilter, search]);
 
   // Group by provider; configured first, then catalog order.
   const grouped = useMemo(() => {
@@ -233,13 +229,6 @@ export function CatalogTab({
           />
           <span className="kbd">⌘K</span>
         </div>
-        <button
-          className={`btn ${configuredOnly ? 'btn-primary' : 'btn-secondary'} btn-sm`}
-          onClick={() => setConfiguredOnly((v) => !v)}
-          title={configuredOnly ? 'Showing only configured providers — click to clear' : 'Show only configured providers'}
-        >
-          <SlidersHorizontal size={13} /> {configuredOnly ? 'Configured only' : 'Filter'}
-        </button>
       </div>
 
       <div className="cat-card">

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -79,6 +79,8 @@ export function CatalogTab({
 }: CatalogTabProps) {
   const [search, setSearch] = useState('');
   const [capFilter, setCapFilter] = useState<CapFilter>('all');
+  /** Show only models from providers whose required keys are saved. */
+  const [configuredOnly, setConfiguredOnly] = useState(false);
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({
     key: 'context',
     dir: 'desc',
@@ -126,6 +128,7 @@ export function CatalogTab({
   const filtered = useMemo(() => {
     let rows = flatRows;
     if (capFilter !== 'all') rows = rows.filter((r) => r.capability === capFilter);
+    if (configuredOnly) rows = rows.filter((r) => configuredProviders.has(r.providerId));
     if (search.trim()) {
       const q = search.toLowerCase();
       rows = rows.filter(
@@ -136,7 +139,7 @@ export function CatalogTab({
       );
     }
     return rows;
-  }, [flatRows, capFilter, search]);
+  }, [flatRows, capFilter, search, configuredOnly, configuredProviders]);
 
   // Group by provider; configured first, then catalog order.
   const grouped = useMemo(() => {
@@ -230,8 +233,12 @@ export function CatalogTab({
           />
           <span className="kbd">⌘K</span>
         </div>
-        <button className="btn btn-secondary btn-sm">
-          <SlidersHorizontal size={13} /> Filter
+        <button
+          className={`btn ${configuredOnly ? 'btn-primary' : 'btn-secondary'} btn-sm`}
+          onClick={() => setConfiguredOnly((v) => !v)}
+          title={configuredOnly ? 'Showing only configured providers — click to clear' : 'Show only configured providers'}
+        >
+          <SlidersHorizontal size={13} /> {configuredOnly ? 'Configured only' : 'Filter'}
         </button>
       </div>
 

--- a/packages/home/src/components/models/ImagePlayground.tsx
+++ b/packages/home/src/components/models/ImagePlayground.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
-import { ArrowLeft, Image as ImageIcon, Loader2, RefreshCw, Sparkles } from 'lucide-react';
+import { ArrowLeft, Image as ImageIcon, Loader2, Sparkles } from 'lucide-react';
 import type {
   DistriHomeClient,
   ImageGenerateResponseImage,
@@ -257,13 +257,6 @@ export function ImagePlayground({
                     <Sparkles size={13} /> Generate
                   </>
                 )}
-              </button>
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={handleGenerate}
-                disabled={generating || !selected}
-              >
-                <RefreshCw size={12} /> Variations
               </button>
             </div>
           </div>

--- a/packages/home/src/components/models/ImagePlayground.tsx
+++ b/packages/home/src/components/models/ImagePlayground.tsx
@@ -1,0 +1,323 @@
+/**
+ * Image generation playground. Two-column layout — prompt + result
+ * canvas on the left, parameter panel on the right. Drives
+ * `homeClient.generateImage` and renders the resulting images inline.
+ *
+ * Hooks the gpt-image-1/2, fal flux/*, and Imagen-style models.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { ArrowLeft, Image as ImageIcon, Loader2, RefreshCw, Sparkles } from 'lucide-react';
+import type {
+  DistriHomeClient,
+  ImageGenerateResponseImage,
+  ModelProviderDefinition,
+} from '../../DistriHomeClient';
+import { CapPill } from './primitives';
+
+interface ImagePlaygroundProps {
+  homeClient: DistriHomeClient;
+  providers: ModelProviderDefinition[];
+  configured: Set<string>;
+  initialProviderId?: string;
+  initialModelId?: string;
+  onBack: () => void;
+}
+
+const QUALITY_OPTIONS: { id: string; label: string }[] = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+];
+const SIZE_OPTIONS = ['1024x1024', '1024x1536', '1536x1024'];
+
+export function ImagePlayground({
+  homeClient,
+  providers,
+  configured,
+  initialProviderId,
+  initialModelId,
+  onBack,
+}: ImagePlaygroundProps) {
+  // Flatten every image-capable model into a {providerId, modelId} list.
+  const imageModels = useMemo(() => {
+    const out: { providerId: string; providerLabel: string; modelId: string; modelName: string }[] = [];
+    for (const p of providers) {
+      for (const m of p.models) {
+        if (m.capability === 'image') {
+          out.push({
+            providerId: p.id,
+            providerLabel: p.label,
+            modelId: m.id,
+            modelName: m.name,
+          });
+        }
+      }
+    }
+    return out;
+  }, [providers]);
+
+  const defaultPick = imageModels.find(
+    (m) => m.providerId === initialProviderId && m.modelId === initialModelId,
+  ) ?? imageModels[0];
+  const [selected, setSelected] = useState(
+    defaultPick ? `${defaultPick.providerId}/${defaultPick.modelId}` : '',
+  );
+
+  const [prompt, setPrompt] = useState(
+    'A wide-angle architectural photo of a brutalist building at golden hour, low-angle, dramatic shadows.',
+  );
+  const [size, setSize] = useState<string>('1024x1024');
+  const [quality, setQuality] = useState<string>('low');
+  const [n, setN] = useState<number>(1);
+  const [generating, setGenerating] = useState(false);
+  const [images, setImages] = useState<ImageGenerateResponseImage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = useCallback(async () => {
+    if (!selected || !prompt.trim()) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const result = await homeClient.generateImage({
+        model: selected,
+        prompt,
+        n,
+        size,
+        quality,
+        response_format: 'b64_json',
+      });
+      setImages(result.images);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Image generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  }, [homeClient, selected, prompt, n, size, quality]);
+
+  if (imageModels.length === 0) {
+    return (
+      <div style={{ padding: 24 }}>
+        <button className="btn btn-ghost btn-sm" onClick={onBack}>
+          <ArrowLeft size={13} /> Catalog
+        </button>
+        <div style={{ marginTop: 24, color: 'var(--m-text-muted)' }}>
+          No image-capable models in the catalog. Configure a provider first.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+        <button className="btn btn-ghost btn-sm" onClick={onBack}>
+          <ArrowLeft size={13} /> Catalog
+        </button>
+        <span style={{ color: 'var(--m-text-faint)' }}>/</span>
+        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>Image playground</h2>
+        <span style={{ flex: 1 }} />
+        <select
+          className="select"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          style={{
+            background: 'rgba(255,255,255,.02)',
+            border: '1px solid var(--m-border)',
+            color: 'var(--m-text)',
+            borderRadius: 'var(--m-radius-md)',
+            padding: '7px 10px',
+            fontSize: 13,
+            minWidth: 280,
+            fontFamily: 'var(--m-font-mono)',
+          }}
+        >
+          {imageModels.map((m) => {
+            const id = `${m.providerId}/${m.modelId}`;
+            const isConfigured = configured.has(m.providerId);
+            return (
+              <option key={id} value={id} disabled={!isConfigured}>
+                {id}
+                {isConfigured ? '' : '  (not configured)'}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+
+      <div className="pg">
+        <div className="surface">
+          <div
+            style={{
+              padding: '14px 18px',
+              borderBottom: '1px solid var(--m-border-soft)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              fontSize: 12.5,
+              color: 'var(--m-text-muted)',
+            }}
+          >
+            <CapPill type="image" />
+            <span className="mono-text">{selected}</span>
+            <span style={{ flex: 1 }} />
+            <span>{n}× {size} · {quality}</span>
+          </div>
+
+          <div className="image-canvas">
+            {Array.from({ length: n }).map((_, i) => {
+              const img = images[i];
+              return (
+                <div key={i} className={`image-tile ${generating ? 'shimmer' : ''}`}>
+                  {!generating && img && (img.b64_json || img.url) && (
+                    <img
+                      src={img.b64_json ? `data:image/png;base64,${img.b64_json}` : img.url}
+                      alt={`Generated ${i}`}
+                    />
+                  )}
+                  {!generating && !img && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: 'var(--m-text-faint)',
+                      }}
+                    >
+                      <ImageIcon size={28} />
+                    </div>
+                  )}
+                  {!generating && img && (
+                    <div className="meta">
+                      {img.width && img.height ? `${img.width}×${img.height}` : size}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {error && (
+            <div
+              style={{
+                padding: '10px 14px',
+                borderTop: '1px solid var(--m-border-soft)',
+                color: '#FDA4AF',
+                fontSize: 12.5,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          <div
+            style={{
+              padding: 14,
+              borderTop: '1px solid var(--m-border-soft)',
+              display: 'grid',
+              gridTemplateColumns: '1fr auto',
+              gap: 10,
+            }}
+          >
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe the image…"
+              rows={2}
+              style={{
+                background: 'rgba(255,255,255,.02)',
+                border: '1px solid var(--m-border)',
+                borderRadius: 'var(--m-radius-md)',
+                padding: '10px 12px',
+                resize: 'vertical',
+                color: 'var(--m-text)',
+                fontSize: 13.5,
+                outline: 0,
+                fontFamily: 'inherit',
+              }}
+            />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <button
+                className="btn btn-primary"
+                onClick={handleGenerate}
+                disabled={generating || !selected || !prompt.trim()}
+              >
+                {generating ? (
+                  <>
+                    <Loader2 size={13} className="shimmer" /> Generating…
+                  </>
+                ) : (
+                  <>
+                    <Sparkles size={13} /> Generate
+                  </>
+                )}
+              </button>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={handleGenerate}
+                disabled={generating || !selected}
+              >
+                <RefreshCw size={12} /> Variations
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="surface params">
+          <ParamSection title="Number of images">
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 6 }}>
+              {[1, 2, 4, 8].map((v) => (
+                <button
+                  key={v}
+                  className={`btn ${n === v ? 'btn-primary' : 'btn-secondary'} btn-sm`}
+                  onClick={() => setN(v)}
+                >
+                  {v}
+                </button>
+              ))}
+            </div>
+          </ParamSection>
+          <ParamSection title="Size">
+            <select
+              className="select"
+              value={size}
+              onChange={(e) => setSize(e.target.value)}
+            >
+              {SIZE_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </ParamSection>
+          <ParamSection title="Quality">
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 6 }}>
+              {QUALITY_OPTIONS.map((q) => (
+                <button
+                  key={q.id}
+                  className={`btn ${quality === q.id ? 'btn-primary' : 'btn-secondary'} btn-sm`}
+                  onClick={() => setQuality(q.id)}
+                >
+                  {q.label}
+                </button>
+              ))}
+            </div>
+          </ParamSection>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ParamSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="param">
+      <div className="lbl">
+        <span>{title}</span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/packages/home/src/components/models/ImagePlayground.tsx
+++ b/packages/home/src/components/models/ImagePlayground.tsx
@@ -11,6 +11,8 @@ import { ArrowLeft, Image as ImageIcon, Loader2, RefreshCw, Sparkles } from 'luc
 import type {
   DistriHomeClient,
   ImageGenerateResponseImage,
+  ImageQuality,
+  ImageSize,
   ModelProviderDefinition,
 } from '../../DistriHomeClient';
 import { CapPill } from './primitives';
@@ -24,12 +26,12 @@ interface ImagePlaygroundProps {
   onBack: () => void;
 }
 
-const QUALITY_OPTIONS: { id: string; label: string }[] = [
+const QUALITY_OPTIONS: { id: ImageQuality; label: string }[] = [
   { id: 'low', label: 'Low' },
   { id: 'medium', label: 'Medium' },
   { id: 'high', label: 'High' },
 ];
-const SIZE_OPTIONS = ['1024x1024', '1024x1536', '1536x1024'];
+const SIZE_OPTIONS: ImageSize[] = ['1024x1024', '1024x1536', '1536x1024'];
 
 export function ImagePlayground({
   homeClient,
@@ -67,8 +69,8 @@ export function ImagePlayground({
   const [prompt, setPrompt] = useState(
     'A wide-angle architectural photo of a brutalist building at golden hour, low-angle, dramatic shadows.',
   );
-  const [size, setSize] = useState<string>('1024x1024');
-  const [quality, setQuality] = useState<string>('low');
+  const [size, setSize] = useState<ImageSize>('1024x1024');
+  const [quality, setQuality] = useState<ImageQuality>('low');
   const [n, setN] = useState<number>(1);
   const [generating, setGenerating] = useState(false);
   const [images, setImages] = useState<ImageGenerateResponseImage[]>([]);
@@ -79,13 +81,15 @@ export function ImagePlayground({
     setGenerating(true);
     setError(null);
     try {
+      // Note: don't send `response_format`. gpt-image-* rejects it (the
+      // model always returns base64). For dall-e-* the server default is
+      // fine; if a caller wants `url` instead they can set it explicitly.
       const result = await homeClient.generateImage({
         model: selected,
         prompt,
         n,
         size,
         quality,
-        response_format: 'b64_json',
       });
       setImages(result.images);
     } catch (err) {
@@ -283,7 +287,7 @@ export function ImagePlayground({
             <select
               className="select"
               value={size}
-              onChange={(e) => setSize(e.target.value)}
+              onChange={(e) => setSize(e.target.value as ImageSize)}
             >
               {SIZE_OPTIONS.map((s) => (
                 <option key={s} value={s}>

--- a/packages/home/src/components/models/ModelDetailDrawer.tsx
+++ b/packages/home/src/components/models/ModelDetailDrawer.tsx
@@ -1,0 +1,296 @@
+/**
+ * Slide-over drawer triggered by clicking a model row. Shows the spec
+ * grid, pricing, voices (TTS), and a "Open playground" action.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Check,
+  Copy,
+  Info,
+  Play,
+  PlayCircle,
+  Star,
+  Wrench,
+  X,
+} from 'lucide-react';
+import type {
+  Model,
+  ModelCapability,
+  ModelProviderDefinition,
+} from '../../DistriHomeClient';
+import { formatContext, providerMonogram } from './data';
+import { CapPill } from './primitives';
+
+interface ModelDetailDrawerProps {
+  provider: ModelProviderDefinition;
+  model: Model;
+  configured: boolean;
+  isDefault: boolean;
+  isStarred: boolean;
+  onClose: () => void;
+  onSetDefault: () => void;
+  onToggleStar: () => void;
+  onOpenPlayground: () => void;
+  onConfigureProvider: () => void;
+}
+
+export function ModelDetailDrawer({
+  provider,
+  model,
+  configured,
+  isDefault,
+  isStarred,
+  onClose,
+  onSetDefault,
+  onToggleStar,
+  onOpenPlayground,
+  onConfigureProvider,
+}: ModelDetailDrawerProps) {
+  const fullId = `${provider.id}/${model.id}`;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (navigator.clipboard) navigator.clipboard.writeText(fullId).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }, [fullId]);
+
+  const codeSample = useMemo(
+    () => `from distri import Agent
+
+agent = Agent(
+  name="my-agent",
+  model="${fullId}",
+)`,
+    [fullId],
+  );
+
+  return (
+    <>
+      <div className="drawer-backdrop" onClick={onClose} />
+      <aside className="drawer">
+        <div className="top">
+          <span className="mono lg">{providerMonogram(provider.id)}</span>
+          <div className="title">
+            <h2>{model.name}</h2>
+            <div className="id">
+              <span>{fullId}</span>
+              <button onClick={handleCopy} title="Copy">
+                {copied ? <Check size={11} /> : <Copy size={11} />}
+              </button>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="btn btn-ghost"
+            style={{ width: 30, height: 30, padding: 0 }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            padding: '12px 22px',
+            borderBottom: '1px solid var(--m-border-soft)',
+            flexWrap: 'wrap',
+          }}
+        >
+          <button className="btn btn-primary" onClick={onOpenPlayground}>
+            <Play size={13} /> Open playground
+          </button>
+          <button className="btn btn-secondary" onClick={onSetDefault}>
+            <Check size={13} /> {isDefault ? 'Default model' : 'Set as default'}
+          </button>
+          <button className="btn btn-secondary" onClick={onToggleStar}>
+            <Star
+              size={13}
+              style={
+                isStarred
+                  ? { color: 'var(--m-brand-soft)', fill: 'currentColor' }
+                  : undefined
+              }
+            />
+            {isStarred ? 'Starred' : 'Star'}
+          </button>
+          <span style={{ flex: 1 }} />
+          <button className="btn btn-ghost btn-sm" onClick={onConfigureProvider}>
+            <Wrench size={12} /> Provider
+          </button>
+        </div>
+
+        <div className="body">
+          {!configured && (
+            <div
+              style={{
+                padding: 12,
+                marginBottom: 18,
+                background: 'rgba(245,158,11,.06)',
+                border: '1px solid rgba(245,158,11,.22)',
+                borderRadius: 'var(--m-radius-md)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                fontSize: 12.5,
+                color: '#FCD34D',
+              }}
+            >
+              <Info size={14} />
+              <span style={{ flex: 1 }}>
+                <strong>{provider.label}</strong> isn't configured — add credentials to enable this model.
+              </span>
+              <button
+                className="btn btn-sm"
+                style={{ background: 'rgba(245,158,11,.18)', color: '#FCD34D' }}
+                onClick={onConfigureProvider}
+              >
+                Configure
+              </button>
+            </div>
+          )}
+
+          <div className="spec-grid">
+            <Spec k="Capability" v={<CapPill type={model.capability} />} />
+            {model.context_window && (
+              <Spec k="Context window" v={`${formatContext(model.context_window)} tokens`} />
+            )}
+            {model.voices?.length && <Spec k="Voices" v={`${model.voices.length}`} />}
+            {model.formats?.length && (
+              <Spec
+                k={
+                  model.capability === 'image'
+                    ? 'Output formats'
+                    : model.capability === 'tts' || model.capability === 'stt'
+                    ? 'Audio formats'
+                    : 'Formats'
+                }
+                v={
+                  <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                    {model.formats.map((f) => (
+                      <span key={f} className="tag">
+                        {f}
+                      </span>
+                    ))}
+                  </div>
+                }
+              />
+            )}
+          </div>
+
+          {model.pricing && (
+            <div className="section">
+              <h3>Pricing</h3>
+              <div className="spec-grid">
+                {model.pricing.type === 'completion' && (
+                  <>
+                    <Spec
+                      k="Input · per 1M tokens"
+                      v={<span style={{ fontWeight: 600 }}>${model.pricing.input.toFixed(2)}</span>}
+                    />
+                    <Spec
+                      k="Output · per 1M tokens"
+                      v={<span style={{ fontWeight: 600 }}>${model.pricing.output.toFixed(2)}</span>}
+                    />
+                    {model.pricing.cached_input != null && (
+                      <Spec
+                        k="Cached input · per 1M"
+                        v={
+                          <span style={{ fontWeight: 600, color: '#6EE7B7' }}>
+                            ${model.pricing.cached_input.toFixed(2)}
+                          </span>
+                        }
+                      />
+                    )}
+                  </>
+                )}
+                {model.pricing.type === 'tts' && (
+                  <Spec
+                    k="Per 1M characters"
+                    v={
+                      <span style={{ fontWeight: 600 }}>
+                        ${model.pricing.per_1m_chars.toFixed(2)}
+                      </span>
+                    }
+                  />
+                )}
+                {model.pricing.type === 'stt' && (
+                  <Spec
+                    k="Per minute audio"
+                    v={
+                      <span style={{ fontWeight: 600 }}>
+                        ${model.pricing.per_minute.toFixed(3)}
+                      </span>
+                    }
+                  />
+                )}
+                {model.pricing.type === 'image' && (
+                  <Spec
+                    k="Per image"
+                    v={
+                      <span style={{ fontWeight: 600 }}>
+                        ${model.pricing.per_image.toFixed(3)}
+                      </span>
+                    }
+                  />
+                )}
+              </div>
+            </div>
+          )}
+
+          {(model.capability as ModelCapability) === 'tts' &&
+            (model.voices?.length ?? 0) > 0 && (
+              <div className="section">
+                <h3>Voices · {model.voices!.length}</h3>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                  {model.voices!.map((v) => (
+                    <div key={v.id} className="voice-card">
+                      <div>
+                        <div className="name">{v.name}</div>
+                        {v.description && <div className="desc">{v.description}</div>}
+                      </div>
+                      <button className="btn btn-ghost btn-sm">
+                        <PlayCircle size={16} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+          <div className="section">
+            <h3>Quick start</h3>
+            <pre
+              style={{
+                margin: 0,
+                padding: 14,
+                background: 'var(--m-bg-sunk)',
+                border: '1px solid var(--m-border)',
+                borderRadius: 'var(--m-radius-md)',
+                fontSize: 12,
+                lineHeight: 1.55,
+                fontFamily: 'var(--m-font-mono)',
+                color: 'var(--m-text-muted)',
+                overflowX: 'auto',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {codeSample}
+            </pre>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function Spec({ k, v }: { k: string; v: React.ReactNode }) {
+  return (
+    <div className="spec-cell">
+      <div className="k">{k}</div>
+      <div className="v">{v}</div>
+    </div>
+  );
+}

--- a/packages/home/src/components/models/ModelDetailDrawer.tsx
+++ b/packages/home/src/components/models/ModelDetailDrawer.tsx
@@ -6,11 +6,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
   Check,
+  CheckCircle2,
   Copy,
   Info,
   Play,
   PlayCircle,
-  Star,
   Wrench,
   X,
 } from 'lucide-react';
@@ -27,10 +27,9 @@ interface ModelDetailDrawerProps {
   model: Model;
   configured: boolean;
   isDefault: boolean;
-  isStarred: boolean;
   onClose: () => void;
+  /** Toggle the model as the workspace default for its capability. */
   onSetDefault: () => void;
-  onToggleStar: () => void;
   onOpenPlayground: () => void;
   onConfigureProvider: () => void;
 }
@@ -40,10 +39,8 @@ export function ModelDetailDrawer({
   model,
   configured,
   isDefault,
-  isStarred,
   onClose,
   onSetDefault,
-  onToggleStar,
   onOpenPlayground,
   onConfigureProvider,
 }: ModelDetailDrawerProps) {
@@ -102,19 +99,13 @@ agent = Agent(
           <button className="btn btn-primary" onClick={onOpenPlayground}>
             <Play size={13} /> Open playground
           </button>
-          <button className="btn btn-secondary" onClick={onSetDefault}>
-            <Check size={13} /> {isDefault ? 'Default model' : 'Set as default'}
-          </button>
-          <button className="btn btn-secondary" onClick={onToggleStar}>
-            <Star
-              size={13}
-              style={
-                isStarred
-                  ? { color: 'var(--m-brand-soft)', fill: 'currentColor' }
-                  : undefined
-              }
-            />
-            {isStarred ? 'Starred' : 'Star'}
+          <button
+            className={`btn ${isDefault ? 'btn-primary' : 'btn-secondary'}`}
+            onClick={onSetDefault}
+            aria-pressed={isDefault}
+          >
+            {isDefault ? <CheckCircle2 size={13} /> : <Check size={13} />}
+            {isDefault ? 'Default — click to clear' : 'Set as default'}
           </button>
           <span style={{ flex: 1 }} />
           <button className="btn btn-ghost btn-sm" onClick={onConfigureProvider}>

--- a/packages/home/src/components/models/ModelsView.tsx
+++ b/packages/home/src/components/models/ModelsView.tsx
@@ -387,6 +387,7 @@ export function ModelsView({
           <ProvidersTab
             providers={providers}
             secrets={secrets}
+            defaults={defaults}
             focusProviderId={focusProviderId}
             onFocusProvider={(id) => go({ view: 'providers', providerId: id })}
             onSaveKey={handleSaveKey}

--- a/packages/home/src/components/models/ModelsView.tsx
+++ b/packages/home/src/components/models/ModelsView.tsx
@@ -1,66 +1,73 @@
 /**
- * Models settings entry point — shell that routes between
- * Catalog, Providers, the model-detail drawer, and the
- * Voice / Image playgrounds.
+ * ModelsView — the full-width Models page. Standalone; no settings shell.
  *
- * Wired to the real `DistriHomeClient`:
- *   listProviders / listSecrets / getWorkspaceSettings
- *   updateWorkspaceSettings (defaults)
- *   upsertProvider (save credential)
- *   deleteSecret (remove credential)
- *   testProvider (probe `GET /models`)
- *   generateImage / generateSpeech (playgrounds)
+ * URL-driven: the consuming app passes `view` + `playgroundMode` and a
+ * `navigate` callback. We render the right sub-page:
+ *   /models             → CatalogTab
+ *   /models/providers   → ProvidersTab
+ *   /models/playground  → Voice or Image playground (per `playgroundMode`)
  *
- * Styling is scoped under `.models-shell` (see ./models/models.css).
- * The shell intentionally bypasses the rest of the app's shadcn
- * theming so the dense dark UI lands as designed.
+ * Owns:
+ *   - server state (providers / secrets / workspace settings),
+ *   - the in-page model-detail drawer,
+ *   - the in-memory favorites set,
+ * and delegates rendering of each view to its dedicated component.
  */
 
-import './models/models.css';
+import './models.css';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Beaker, Layers, Settings as SettingsIcon } from 'lucide-react';
-import { CAPABILITY_META } from './models/data';
-import { useDistriHomeClient } from '../provider/context';
+import { useDistriHomeClient } from '../../provider/context';
 import type {
   CustomModelEntry,
   ModelCapability,
   ModelProviderDefinition,
   Secret,
-} from '../DistriHomeClient';
-import { CatalogTab } from './models/CatalogTab';
-import { ImagePlayground } from './models/ImagePlayground';
-import { ModelDetailDrawer } from './models/ModelDetailDrawer';
-import type { AddCustomProviderInput } from './models/ProvidersTab';
-import { ProvidersTab } from './models/ProvidersTab';
-import { VoicePlayground } from './models/VoicePlayground';
+} from '../../DistriHomeClient';
+import { CAPABILITY_META } from './data';
+import { CatalogTab } from './CatalogTab';
+import { ImagePlayground } from './ImagePlayground';
+import { ModelDetailDrawer } from './ModelDetailDrawer';
+import type { AddCustomProviderInput } from './ProvidersTab';
+import { ProvidersTab } from './ProvidersTab';
+import { VoicePlayground } from './VoicePlayground';
 
-export interface AgentSettingsViewProps {
+export type ModelsViewMode = 'catalog' | 'providers' | 'playground';
+export type PlaygroundCapability = 'tts' | 'image';
+
+export type ModelsNavigateTarget =
+  | { view: 'catalog' }
+  | { view: 'providers'; providerId?: string }
+  | { view: 'playground'; mode: PlaygroundCapability; providerId?: string; modelId?: string };
+
+export interface ModelsViewProps {
   className?: string;
-  /** Active tab from URL: 'models' (default) or 'providers'. */
-  activeTab?: 'models' | 'providers';
-  /** Callback when tab changes — consumer should update URL. */
-  onTabChange?: (tab: 'models' | 'providers') => void;
+  /** Which sub-page to render. Defaults to `catalog`. */
+  view?: ModelsViewMode;
+  /** Playground capability (only when `view === 'playground'`). */
+  playgroundMode?: PlaygroundCapability;
+  /** Initial provider id to focus on the Providers tab. */
+  focusProviderId?: string;
+  /** Initial model id for the playground. */
+  playgroundProviderId?: string;
+  playgroundModelId?: string;
+  /** Consumer routes to the right URL. */
+  navigate?: (target: ModelsNavigateTarget) => void;
 }
 
-type PlaygroundMode = { capability: 'image' | 'tts'; providerId?: string; modelId?: string } | null;
 type DrawerTarget = { providerId: string; modelId: string } | null;
 
-export function AgentSettingsView({
+export function ModelsView({
   className,
-  activeTab: activeTabProp,
-  onTabChange,
-}: AgentSettingsViewProps) {
+  view = 'catalog',
+  playgroundMode = 'tts',
+  focusProviderId,
+  playgroundProviderId,
+  playgroundModelId,
+  navigate,
+}: ModelsViewProps) {
   const homeClient = useDistriHomeClient();
-  const [activeTabInternal, setActiveTabInternal] = useState<'models' | 'providers'>(
-    activeTabProp ?? 'models',
-  );
-  const activeTab = activeTabProp ?? activeTabInternal;
-
-  const setActiveTab = (t: 'models' | 'providers') => {
-    setActiveTabInternal(t);
-    onTabChange?.(t);
-  };
 
   // ── Server state ──
   const [providers, setProviders] = useState<ModelProviderDefinition[]>([]);
@@ -71,18 +78,15 @@ export function AgentSettingsView({
     stt: '',
     image: '',
   });
-  const [customModels, setCustomModels] = useState<CustomModelEntry[]>([]); // kept for symmetry; UI lands later
+  // Kept around; the inline-add-model UI lands later.
+  const [customModels, setCustomModels] = useState<CustomModelEntry[]>([]);
+  void customModels;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   // ── Local UI state ──
   const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [drawer, setDrawer] = useState<DrawerTarget>(null);
-  const [playground, setPlayground] = useState<PlaygroundMode>(null);
-  const [focusProviderId, setFocusProviderId] = useState<string | undefined>(undefined);
-
-  // Avoid an unused warning while the field stays on the type.
-  void customModels;
 
   const loadData = useCallback(async () => {
     if (!homeClient) return;
@@ -100,7 +104,10 @@ export function AgentSettingsView({
         completion: settings?.default_model ?? '',
         tts: settings?.default_tts_model ?? '',
         stt: settings?.default_stt_model ?? '',
-        image: (settings as Record<string, unknown> | null)?.default_image_model as string | undefined ?? '',
+        image:
+          ((settings as Record<string, unknown> | null)?.default_image_model as
+            | string
+            | undefined) ?? '',
       });
       setCustomModels(settings?.custom_models ?? []);
     } catch (err) {
@@ -125,7 +132,20 @@ export function AgentSettingsView({
     return set;
   }, [providers, secrets]);
 
-  // ── Actions ──
+  const totalModels = useMemo(
+    () => providers.reduce((n, p) => n + p.models.length, 0),
+    [providers],
+  );
+
+  // ── Navigation ──
+  const go = useCallback(
+    (target: ModelsNavigateTarget) => {
+      if (navigate) navigate(target);
+    },
+    [navigate],
+  );
+
+  // ── Actions wired to providers/playgrounds ──
   const toggleFavorite = (fullId: string) =>
     setFavorites((prev) => {
       const next = new Set(prev);
@@ -137,30 +157,21 @@ export function AgentSettingsView({
   const handleOpenModel = (providerId: string, modelId: string) =>
     setDrawer({ providerId, modelId });
 
-  const handleOpenPlayground = (capability: ModelCapability, providerId: string, modelId: string) => {
-    if (capability === 'image' || capability === 'tts') {
-      setPlayground({ capability, providerId, modelId });
+  const handleOpenPlayground = (
+    capability: ModelCapability,
+    providerId: string,
+    modelId: string,
+  ) => {
+    if (capability === 'tts' || capability === 'image') {
+      go({ view: 'playground', mode: capability, providerId, modelId });
     } else {
-      // No completion/STT playground built yet — fall through to drawer.
+      // Completion / STT playgrounds aren't built yet — fall through to drawer.
       setDrawer({ providerId, modelId });
     }
   };
 
-  const handleConfigureProvider = (providerId: string) => {
-    setFocusProviderId(providerId);
-    setActiveTab('providers');
-  };
-
-  const handleChangeDefault = async (capability: ModelCapability) => {
-    // The catalog's default cards trigger this. For now, just jump to
-    // the capability-filtered catalog so the user can click a model
-    // and use the drawer's "Set as default". The drawer wires the
-    // actual updateWorkspaceSettings call.
-    setPlayground(null);
-    setDrawer(null);
-    // No-op aside from filtering would be confusing; keep noop.
-    void capability;
-  };
+  const handleConfigureProvider = (providerId: string) =>
+    go({ view: 'providers', providerId });
 
   const handleSetDefaultForModel = async (capability: ModelCapability, fullId: string) => {
     if (!homeClient) return;
@@ -193,11 +204,21 @@ export function AgentSettingsView({
     await loadData();
   };
 
+  const handleTestProvider = async (providerId: string) => {
+    if (!homeClient) return { ok: false, detail: 'No client' };
+    try {
+      const result = await homeClient.testProvider(providerId);
+      const detail = result.ok
+        ? `Connected — ${result.models.length} models reachable`
+        : result.error ?? 'Test failed';
+      return { ok: result.ok, detail };
+    } catch (err) {
+      return { ok: false, detail: err instanceof Error ? err.message : 'Test failed' };
+    }
+  };
+
   const handleAddCustomProvider = async (input: AddCustomProviderInput) => {
     if (!homeClient) return;
-    // Convention: the backend's `from_provider_model_str` accepts any
-    // `custom_*` prefix and routes it to OpenAICompatible. We derive a
-    // stable id from the display name to avoid surprise collisions.
     const slug = input.name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '_')
@@ -216,23 +237,10 @@ export function AgentSettingsView({
       },
     });
     await loadData();
-    setFocusProviderId(providerId);
+    go({ view: 'providers', providerId });
   };
 
-  const handleTestProvider = async (providerId: string) => {
-    if (!homeClient) return { ok: false, detail: 'No client' };
-    try {
-      const result = await homeClient.testProvider(providerId);
-      const detail = result.ok
-        ? `Connected — ${result.models.length} models reachable`
-        : result.error ?? 'Test failed';
-      return { ok: result.ok, detail };
-    } catch (err) {
-      return { ok: false, detail: err instanceof Error ? err.message : 'Test failed' };
-    }
-  };
-
-  // ── Renders ──
+  // ── Drawer resolution ──
   const drawerData = useMemo(() => {
     if (!drawer) return null;
     const provider = providers.find((p) => p.id === drawer.providerId);
@@ -241,6 +249,7 @@ export function AgentSettingsView({
     return { provider, model };
   }, [drawer, providers]);
 
+  // ── Render ──
   if (loading) {
     return (
       <div className={`models-shell ${className ?? ''}`}>
@@ -250,7 +259,6 @@ export function AgentSettingsView({
       </div>
     );
   }
-
   if (error) {
     return (
       <div className={`models-shell ${className ?? ''}`}>
@@ -261,19 +269,21 @@ export function AgentSettingsView({
     );
   }
 
+  const isPlayground = view === 'playground';
+
   return (
     <div className={`models-shell ${className ?? ''}`}>
       <div className="page">
         <div className="toolbar-row">
-          {playground ? (
+          {isPlayground ? (
             <>
-              <button className="subtab back" onClick={() => setPlayground(null)}>
+              <button className="subtab back" onClick={() => go({ view: 'catalog' })}>
                 <ArrowLeft size={13} /> Models
               </button>
               <span className="tb-sep" />
               <div className="cap-switcher">
                 {(['tts', 'image'] as const).map((c) => {
-                  const active = playground.capability === c;
+                  const active = playgroundMode === c;
                   return (
                     <button
                       key={c}
@@ -281,8 +291,9 @@ export function AgentSettingsView({
                       onClick={() => {
                         const def = defaults[c];
                         const [pid, mid] = (def || '').split('/');
-                        setPlayground({
-                          capability: c,
+                        go({
+                          view: 'playground',
+                          mode: c,
                           providerId: pid || undefined,
                           modelId: mid || undefined,
                         });
@@ -299,23 +310,23 @@ export function AgentSettingsView({
             <>
               <div className="subtabs">
                 <button
-                  className={`subtab ${activeTab === 'models' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('models')}
+                  className={`subtab ${view === 'catalog' ? 'active' : ''}`}
+                  onClick={() => go({ view: 'catalog' })}
                 >
                   <Layers size={14} /> Models
-                  <span className="subtab-count">
-                    {providers.reduce((n, p) => n + p.models.length, 0)}
-                  </span>
+                  <span className="subtab-count">{totalModels}</span>
                 </button>
                 <button
-                  className={`subtab ${activeTab === 'providers' ? 'active' : ''}`}
-                  onClick={() => setActiveTab('providers')}
+                  className={`subtab ${view === 'providers' ? 'active' : ''}`}
+                  onClick={() => go({ view: 'providers' })}
                 >
                   <SettingsIcon size={14} /> Providers
                   <span
                     className="subtab-count"
                     style={{
-                      color: configuredProviders.size ? '#6EE7B7' : 'var(--m-text-faint)',
+                      color: configuredProviders.size
+                        ? '#6EE7B7'
+                        : 'var(--m-text-faint)',
                     }}
                   >
                     {configuredProviders.size}/{providers.length}
@@ -326,12 +337,11 @@ export function AgentSettingsView({
               <button
                 className="btn btn-primary btn-sm"
                 onClick={() => {
-                  // Open Voice playground by default — Completion has no
-                  // playground component built yet; Voice + Image are wired.
                   const def = defaults.tts;
                   const [pid, mid] = (def || '').split('/');
-                  setPlayground({
-                    capability: 'tts',
+                  go({
+                    view: 'playground',
+                    mode: 'tts',
                     providerId: pid || undefined,
                     modelId: mid || undefined,
                   });
@@ -343,27 +353,7 @@ export function AgentSettingsView({
           )}
         </div>
 
-        {playground?.capability === 'image' && homeClient && (
-          <ImagePlayground
-            homeClient={homeClient}
-            providers={providers}
-            configured={configuredProviders}
-            initialProviderId={playground.providerId}
-            initialModelId={playground.modelId}
-            onBack={() => setPlayground(null)}
-          />
-        )}
-        {playground?.capability === 'tts' && homeClient && (
-          <VoicePlayground
-            homeClient={homeClient}
-            providers={providers}
-            configured={configuredProviders}
-            initialProviderId={playground.providerId}
-            initialModelId={playground.modelId}
-            onBack={() => setPlayground(null)}
-          />
-        )}
-        {!playground && activeTab === 'models' && (
+        {view === 'catalog' && (
           <CatalogTab
             providers={providers}
             secrets={secrets}
@@ -373,19 +363,39 @@ export function AgentSettingsView({
             onOpenModel={handleOpenModel}
             onOpenPlayground={handleOpenPlayground}
             onConfigureProvider={handleConfigureProvider}
-            onChangeDefault={handleChangeDefault}
+            onChangeDefault={() => {}}
           />
         )}
-        {!playground && activeTab === 'providers' && (
+        {view === 'providers' && (
           <ProvidersTab
             providers={providers}
             secrets={secrets}
             focusProviderId={focusProviderId}
-            onFocusProvider={setFocusProviderId}
+            onFocusProvider={(id) => go({ view: 'providers', providerId: id })}
             onSaveKey={handleSaveKey}
             onDeleteKey={handleDeleteKey}
             onTestProvider={handleTestProvider}
             onAddCustomProvider={handleAddCustomProvider}
+          />
+        )}
+        {isPlayground && playgroundMode === 'tts' && homeClient && (
+          <VoicePlayground
+            homeClient={homeClient}
+            providers={providers}
+            configured={configuredProviders}
+            initialProviderId={playgroundProviderId}
+            initialModelId={playgroundModelId}
+            onBack={() => go({ view: 'catalog' })}
+          />
+        )}
+        {isPlayground && playgroundMode === 'image' && homeClient && (
+          <ImagePlayground
+            homeClient={homeClient}
+            providers={providers}
+            configured={configuredProviders}
+            initialProviderId={playgroundProviderId}
+            initialModelId={playgroundModelId}
+            onBack={() => go({ view: 'catalog' })}
           />
         )}
       </div>
@@ -395,8 +405,13 @@ export function AgentSettingsView({
           provider={drawerData.provider}
           model={drawerData.model}
           configured={configuredProviders.has(drawerData.provider.id)}
-          isDefault={defaults[drawerData.model.capability] === `${drawerData.provider.id}/${drawerData.model.id}`}
-          isStarred={favorites.has(`${drawerData.provider.id}/${drawerData.model.id}`)}
+          isDefault={
+            defaults[drawerData.model.capability] ===
+            `${drawerData.provider.id}/${drawerData.model.id}`
+          }
+          isStarred={favorites.has(
+            `${drawerData.provider.id}/${drawerData.model.id}`,
+          )}
           onClose={() => setDrawer(null)}
           onSetDefault={() =>
             handleSetDefaultForModel(
@@ -409,7 +424,11 @@ export function AgentSettingsView({
           }
           onOpenPlayground={() => {
             const cap = drawerData.model.capability;
-            handleOpenPlayground(cap, drawerData.provider.id, drawerData.model.id);
+            handleOpenPlayground(
+              cap,
+              drawerData.provider.id,
+              drawerData.model.id,
+            );
             setDrawer(null);
           }}
           onConfigureProvider={() => {

--- a/packages/home/src/components/models/ModelsView.tsx
+++ b/packages/home/src/components/models/ModelsView.tsx
@@ -10,7 +10,6 @@
  * Owns:
  *   - server state (providers / secrets / workspace settings),
  *   - the in-page model-detail drawer,
- *   - the in-memory favorites set,
  * and delegates rendering of each view to its dedicated component.
  */
 
@@ -85,7 +84,6 @@ export function ModelsView({
   const [error, setError] = useState<string | null>(null);
 
   // ── Local UI state ──
-  const [favorites, setFavorites] = useState<Set<string>>(new Set());
   const [drawer, setDrawer] = useState<DrawerTarget>(null);
 
   const loadData = useCallback(async () => {
@@ -146,13 +144,6 @@ export function ModelsView({
   );
 
   // ── Actions wired to providers/playgrounds ──
-  const toggleFavorite = (fullId: string) =>
-    setFavorites((prev) => {
-      const next = new Set(prev);
-      if (next.has(fullId)) next.delete(fullId);
-      else next.add(fullId);
-      return next;
-    });
 
   const handleOpenModel = (providerId: string, modelId: string) =>
     setDrawer({ providerId, modelId });
@@ -358,12 +349,10 @@ export function ModelsView({
             providers={providers}
             secrets={secrets}
             defaults={defaults}
-            favorites={favorites}
-            onToggleFavorite={toggleFavorite}
+            onSetDefault={handleSetDefaultForModel}
             onOpenModel={handleOpenModel}
             onOpenPlayground={handleOpenPlayground}
             onConfigureProvider={handleConfigureProvider}
-            onChangeDefault={() => {}}
           />
         )}
         {view === 'providers' && (
@@ -409,18 +398,12 @@ export function ModelsView({
             defaults[drawerData.model.capability] ===
             `${drawerData.provider.id}/${drawerData.model.id}`
           }
-          isStarred={favorites.has(
-            `${drawerData.provider.id}/${drawerData.model.id}`,
-          )}
           onClose={() => setDrawer(null)}
           onSetDefault={() =>
             handleSetDefaultForModel(
               drawerData.model.capability,
               `${drawerData.provider.id}/${drawerData.model.id}`,
             )
-          }
-          onToggleStar={() =>
-            toggleFavorite(`${drawerData.provider.id}/${drawerData.model.id}`)
           }
           onOpenPlayground={() => {
             const cap = drawerData.model.capability;

--- a/packages/home/src/components/models/ModelsView.tsx
+++ b/packages/home/src/components/models/ModelsView.tsx
@@ -16,7 +16,7 @@
 import './models.css';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Beaker, Layers, Settings as SettingsIcon } from 'lucide-react';
+import { ArrowLeft, Beaker, Layers, Loader2, Settings as SettingsIcon, X } from 'lucide-react';
 import { useDistriHomeClient } from '../../provider/context';
 import type {
   CustomModelEntry,
@@ -85,6 +85,8 @@ export function ModelsView({
 
   // ── Local UI state ──
   const [drawer, setDrawer] = useState<DrawerTarget>(null);
+  /** When set, the Add Custom Model modal is open for this provider id. */
+  const [addModelFor, setAddModelFor] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     if (!homeClient) return;
@@ -206,6 +208,32 @@ export function ModelsView({
     } catch (err) {
       return { ok: false, detail: err instanceof Error ? err.message : 'Test failed' };
     }
+  };
+
+  /** Add a custom model to a built-in or custom provider. The backend
+   *  replaces the full `custom_models` array on each upsert, so we
+   *  send the existing list plus the new entry. */
+  const handleAddCustomModel = async (
+    providerId: string,
+    modelId: string,
+    capability: ModelCapability,
+  ) => {
+    if (!homeClient) return;
+    const trimmed = modelId.trim();
+    if (!trimmed) return;
+    // Avoid creating a duplicate row.
+    const exists = customModels.some(
+      (m) => m.provider === providerId && m.model === trimmed,
+    );
+    const next = exists
+      ? customModels
+      : [...customModels, { provider: providerId, model: trimmed, capability }];
+    await homeClient.upsertProvider({
+      provider_id: providerId,
+      custom_models: next,
+    });
+    await loadData();
+    setAddModelFor(null);
   };
 
   const handleAddCustomProvider = async (input: AddCustomProviderInput) => {
@@ -365,6 +393,7 @@ export function ModelsView({
             onDeleteKey={handleDeleteKey}
             onTestProvider={handleTestProvider}
             onAddCustomProvider={handleAddCustomProvider}
+            onAddModel={(providerId) => setAddModelFor(providerId)}
           />
         )}
         {isPlayground && playgroundMode === 'tts' && homeClient && (
@@ -420,6 +449,174 @@ export function ModelsView({
           }}
         />
       )}
+
+      {addModelFor && (
+        <AddCustomModelModal
+          provider={
+            providers.find((p) => p.id === addModelFor) ?? null
+          }
+          onClose={() => setAddModelFor(null)}
+          onSubmit={(modelId, capability) =>
+            handleAddCustomModel(addModelFor, modelId, capability)
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+// ── AddCustomModelModal ──────────────────────────────────────────────
+//
+// Simple form: Model ID + Capability. Save calls back into ModelsView
+// with the values; ModelsView appends to `custom_models` and upserts.
+
+function AddCustomModelModal({
+  provider,
+  onClose,
+  onSubmit,
+}: {
+  provider: ModelProviderDefinition | null;
+  onClose: () => void;
+  onSubmit: (modelId: string, capability: ModelCapability) => Promise<void>;
+}) {
+  const [modelId, setModelId] = useState('');
+  const [capability, setCapability] = useState<ModelCapability>('completion');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!provider) return null;
+
+  const handleSubmit = async () => {
+    if (!modelId.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(modelId.trim(), capability);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add model');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="drawer-backdrop"
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 440,
+          maxWidth: '92vw',
+          background: 'var(--m-bg-elev)',
+          border: '1px solid var(--m-border)',
+          borderRadius: 'var(--m-radius-lg)',
+          padding: 20,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 14,
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: 16, color: 'var(--m-text)' }}>
+            Add model to {provider.label}
+          </h3>
+          <button onClick={onClose} className="btn btn-ghost" style={{ width: 28, height: 28, padding: 0 }}>
+            <X size={16} />
+          </button>
+        </div>
+        <p style={{ fontSize: 12.5, color: 'var(--m-text-muted)', margin: '0 0 16px' }}>
+          Type the provider-side model id (e.g. <code className="mono-text" style={{ fontSize: 11 }}>gpt-5.4</code>).
+          It will be stored in workspace settings and surface in the catalog.
+        </p>
+
+        <div style={{ marginBottom: 12 }}>
+          <label
+            style={{
+              display: 'block',
+              fontSize: 12,
+              color: 'var(--m-text-muted)',
+              marginBottom: 5,
+            }}
+          >
+            Model ID
+          </label>
+          <div className="input">
+            <input
+              type="text"
+              placeholder="gpt-5.4"
+              value={modelId}
+              onChange={(e) => setModelId(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && modelId.trim()) handleSubmit();
+              }}
+              autoFocus
+              style={{ fontFamily: 'var(--m-font-mono)' }}
+            />
+          </div>
+        </div>
+
+        <div style={{ marginBottom: 12 }}>
+          <label
+            style={{
+              display: 'block',
+              fontSize: 12,
+              color: 'var(--m-text-muted)',
+              marginBottom: 5,
+            }}
+          >
+            Capability
+          </label>
+          <select
+            value={capability}
+            onChange={(e) => setCapability(e.target.value as ModelCapability)}
+            className="select"
+            style={{
+              width: '100%',
+              background: 'rgba(255,255,255,.02)',
+              border: '1px solid var(--m-border)',
+              color: 'var(--m-text)',
+              borderRadius: 'var(--m-radius-md)',
+              padding: '8px 10px',
+              fontSize: 13,
+            }}
+          >
+            <option value="completion">Completion</option>
+            <option value="tts">Text to speech</option>
+            <option value="stt">Speech to text</option>
+            <option value="image">Image</option>
+          </select>
+        </div>
+
+        {error && (
+          <div style={{ color: '#FDA4AF', fontSize: 12.5, marginTop: 4 }}>{error}</div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+          <button className="btn btn-secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={!modelId.trim() || submitting}
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={13} className="shimmer" /> Adding…
+              </>
+            ) : (
+              'Add model'
+            )}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -169,11 +169,13 @@ function ProviderRail({
           {providers.length} providers
         </span>
         <button
-          className="btn btn-ghost btn-sm"
-          style={{ paddingLeft: 6, paddingRight: 6 }}
+          className="btn btn-secondary btn-sm"
+          style={{ width: 26, padding: 0 }}
           onClick={onAddCustom}
+          title="Add custom provider"
+          aria-label="Add custom provider"
         >
-          <Plus size={12} /> Custom
+          <Plus size={14} />
         </button>
       </div>
       {providers.map((p) => {

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -41,6 +41,8 @@ interface ProvidersTabProps {
   /** Add an OpenAI-compatible custom provider. Resolves once the catalog
    *  has been refreshed and the new entry shows up in `providers`. */
   onAddCustomProvider: (input: AddCustomProviderInput) => Promise<void>;
+  /** Open the Add Custom Model modal scoped to the given provider. */
+  onAddModel: (providerId: string) => void;
 }
 
 export interface AddCustomProviderInput {
@@ -63,6 +65,7 @@ export function ProvidersTab({
   onDeleteKey,
   onTestProvider,
   onAddCustomProvider,
+  onAddModel,
 }: ProvidersTabProps) {
   const [showAddCustom, setShowAddCustom] = useState(false);
   const configured = useMemo(() => {
@@ -118,6 +121,7 @@ export function ProvidersTab({
         onSaveKey={onSaveKey}
         onDeleteKey={onDeleteKey}
         onTestProvider={onTestProvider}
+        onAddModel={() => onAddModel(current.id)}
       />
       {showAddCustom && (
         <AddCustomProviderModal
@@ -213,6 +217,7 @@ function ProviderPanel({
   onSaveKey,
   onDeleteKey,
   onTestProvider,
+  onAddModel,
 }: {
   provider: ModelProviderDefinition;
   secrets: Secret[];
@@ -220,6 +225,7 @@ function ProviderPanel({
   onSaveKey: (providerId: string, key: string, value: string) => Promise<void>;
   onDeleteKey: (key: string) => Promise<void>;
   onTestProvider: (providerId: string) => Promise<{ ok: boolean; detail: string }>;
+  onAddModel: () => void;
 }) {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [savingKey, setSavingKey] = useState<string | null>(null);
@@ -381,6 +387,10 @@ function ProviderPanel({
             <span style={{ fontSize: 11.5, color: 'var(--m-text-faint)' }}>
               {provider.models.length} available
             </span>
+            <span style={{ flex: 1 }} />
+            <button className="btn btn-secondary btn-sm" onClick={onAddModel}>
+              <Plus size={12} /> Add model
+            </button>
           </div>
           <div
             style={{

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -20,6 +20,7 @@ import {
   X,
 } from 'lucide-react';
 import type {
+  ModelCapability,
   ModelProviderDefinition,
   ProviderKeyDefinition,
   Secret,
@@ -30,6 +31,14 @@ import { CapPill, MonoChip } from './primitives';
 interface ProvidersTabProps {
   providers: ModelProviderDefinition[];
   secrets: Secret[];
+  /** Workspace defaults keyed by capability. The default provider for
+   *  each capability is derived from the `"provider/model"` value. */
+  defaults: {
+    completion: string;
+    tts: string;
+    stt: string;
+    image: string;
+  };
   focusProviderId?: string;
   onFocusProvider: (providerId: string) => void;
   /** Save (upsert) a single key. */
@@ -59,6 +68,7 @@ export interface AddCustomProviderInput {
 export function ProvidersTab({
   providers,
   secrets,
+  defaults,
   focusProviderId,
   onFocusProvider,
   onSaveKey,
@@ -68,6 +78,27 @@ export function ProvidersTab({
   onAddModel,
 }: ProvidersTabProps) {
   const [showAddCustom, setShowAddCustom] = useState(false);
+
+  // Capability → provider id, derived from the workspace defaults. The
+  // default model is `"provider/model"`, so the provider is the prefix.
+  // Guard against an undefined `defaults` prop in case a consumer hasn't
+  // upgraded yet — fall back to the empty record.
+  const defaultsByProvider = useMemo(() => {
+    const map = new Map<string, ModelCapability[]>();
+    const caps: ModelCapability[] = ['completion', 'tts', 'stt', 'image'];
+    const d = defaults ?? { completion: '', tts: '', stt: '', image: '' };
+    for (const cap of caps) {
+      const full = d[cap];
+      if (!full) continue;
+      const slash = full.indexOf('/');
+      if (slash <= 0) continue;
+      const providerId = full.slice(0, slash);
+      const list = map.get(providerId) ?? [];
+      list.push(cap);
+      map.set(providerId, list);
+    }
+    return map;
+  }, [defaults]);
   const configured = useMemo(() => {
     const set = new Set<string>();
     for (const p of providers) {
@@ -109,6 +140,7 @@ export function ProvidersTab({
       <ProviderRail
         providers={sorted}
         configured={configured}
+        defaultsByProvider={defaultsByProvider}
         focusId={focusId}
         onFocus={onFocusProvider}
         onAddCustom={() => setShowAddCustom(true)}
@@ -118,6 +150,8 @@ export function ProvidersTab({
         provider={current}
         secrets={secrets}
         configured={configured.has(current.id)}
+        defaults={defaults}
+        defaultCapabilities={defaultsByProvider.get(current.id) ?? []}
         onSaveKey={onSaveKey}
         onDeleteKey={onDeleteKey}
         onTestProvider={onTestProvider}
@@ -139,12 +173,14 @@ export function ProvidersTab({
 function ProviderRail({
   providers,
   configured,
+  defaultsByProvider,
   focusId,
   onFocus,
   onAddCustom,
 }: {
   providers: ModelProviderDefinition[];
   configured: Set<string>;
+  defaultsByProvider: Map<string, ModelCapability[]>;
   focusId: string;
   onFocus: (id: string) => void;
   onAddCustom: () => void;
@@ -185,6 +221,7 @@ function ProviderRail({
       {providers.map((p) => {
         const conf = configured.has(p.id);
         const active = p.id === focusId;
+        const defaultCaps = defaultsByProvider.get(p.id);
         return (
           <div
             key={p.id}
@@ -195,7 +232,30 @@ function ProviderRail({
               {providerMonogram(p.id)}
             </span>
             <div>
-              <div className="label">{p.label}</div>
+              <div
+                className="label"
+                style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                <span>{p.label}</span>
+                {defaultCaps && defaultCaps.length > 0 && (
+                  <span
+                    title={`Default for ${defaultCaps.map((c) => CAPABILITY_META[c].short).join(', ')}`}
+                    style={{
+                      fontSize: 9.5,
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      fontWeight: 600,
+                      color: 'var(--m-brand-soft)',
+                      background: 'rgba(34,174,195,.14)',
+                      border: '1px solid rgba(34,174,195,.32)',
+                      borderRadius: 4,
+                      padding: '1px 5px',
+                    }}
+                  >
+                    Default
+                  </span>
+                )}
+              </div>
               <div className="sub">
                 <span className={`status-dot ${conf ? 'ok' : ''}`} />
                 <span>{conf ? 'Configured' : 'Not configured'}</span>
@@ -214,6 +274,8 @@ function ProviderPanel({
   provider,
   secrets,
   configured,
+  defaults,
+  defaultCapabilities,
   onSaveKey,
   onDeleteKey,
   onTestProvider,
@@ -222,6 +284,8 @@ function ProviderPanel({
   provider: ModelProviderDefinition;
   secrets: Secret[];
   configured: boolean;
+  defaults: ProvidersTabProps['defaults'];
+  defaultCapabilities: ModelCapability[];
   onSaveKey: (providerId: string, key: string, value: string) => Promise<void>;
   onDeleteKey: (key: string) => Promise<void>;
   onTestProvider: (providerId: string) => Promise<{ ok: boolean; detail: string }>;
@@ -284,7 +348,27 @@ function ProviderPanel({
           {providerMonogram(provider.id)}
         </span>
         <div>
-          <h2>{provider.label}</h2>
+          <h2 style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <span>{provider.label}</span>
+            {defaultCapabilities.length > 0 && (
+              <span
+                title={`Workspace default for ${defaultCapabilities.map((c) => CAPABILITY_META[c].short).join(', ')}`}
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.10em',
+                  textTransform: 'uppercase',
+                  fontWeight: 700,
+                  color: 'var(--m-brand-soft)',
+                  background: 'rgba(34,174,195,.14)',
+                  border: '1px solid rgba(34,174,195,.32)',
+                  borderRadius: 4,
+                  padding: '2px 6px',
+                }}
+              >
+                Default · {defaultCapabilities.map((c) => CAPABILITY_META[c].short).join(' · ')}
+              </span>
+            )}
+          </h2>
           <div className="sub">
             <span style={{ color: configured ? '#6EE7B7' : 'var(--m-text-faint)' }}>
               {configured ? '● Configured' : '○ Not configured'}
@@ -399,31 +483,55 @@ function ProviderPanel({
               overflow: 'hidden',
             }}
           >
-            {provider.models.map((m, idx) => (
-              <div
-                key={m.id}
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr auto auto',
-                  gap: 14,
-                  alignItems: 'center',
-                  padding: '10px 14px',
-                  borderTop: idx === 0 ? '0' : '1px solid var(--m-border-soft)',
-                }}
-              >
-                <div>
-                  <div style={{ fontSize: 13, fontWeight: 500 }}>{m.name}</div>
-                  <div
-                    className="mono-text"
-                    style={{ fontSize: 11, color: 'var(--m-text-faint)', marginTop: 1 }}
-                  >
-                    {provider.id}/{m.id}
+            {provider.models.map((m, idx) => {
+              const isDefault = defaults?.[m.capability] === `${provider.id}/${m.id}`;
+              return (
+                <div
+                  key={m.id}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto auto auto',
+                    gap: 14,
+                    alignItems: 'center',
+                    padding: '10px 14px',
+                    borderTop: idx === 0 ? '0' : '1px solid var(--m-border-soft)',
+                    background: isDefault ? 'rgba(34,174,195,.04)' : undefined,
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 500 }}>{m.name}</div>
+                    <div
+                      className="mono-text"
+                      style={{ fontSize: 11, color: 'var(--m-text-faint)', marginTop: 1 }}
+                    >
+                      {provider.id}/{m.id}
+                    </div>
                   </div>
+                  {isDefault ? (
+                    <span
+                      title={`Workspace default for ${CAPABILITY_META[m.capability].short}`}
+                      style={{
+                        fontSize: 10,
+                        letterSpacing: '0.10em',
+                        textTransform: 'uppercase',
+                        fontWeight: 700,
+                        color: 'var(--m-brand-soft)',
+                        background: 'rgba(34,174,195,.14)',
+                        border: '1px solid rgba(34,174,195,.32)',
+                        borderRadius: 4,
+                        padding: '2px 6px',
+                      }}
+                    >
+                      Default
+                    </span>
+                  ) : (
+                    <span />
+                  )}
+                  <CapPill type={m.capability} />
+                  <MonoChip providerId={provider.id} />
                 </div>
-                <CapPill type={m.capability} />
-                <MonoChip providerId={provider.id} />
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -38,6 +38,20 @@ interface ProvidersTabProps {
   onDeleteKey: (key: string) => Promise<void>;
   /** Test a provider's connection via `POST /v1/providers/test`. */
   onTestProvider: (providerId: string) => Promise<{ ok: boolean; detail: string }>;
+  /** Add an OpenAI-compatible custom provider. Resolves once the catalog
+   *  has been refreshed and the new entry shows up in `providers`. */
+  onAddCustomProvider: (input: AddCustomProviderInput) => Promise<void>;
+}
+
+export interface AddCustomProviderInput {
+  /** Display name shown in the provider rail. */
+  name: string;
+  /** OpenAI-compatible `/v1` base URL. */
+  baseUrl: string;
+  /** API key — stored as the provider's `OPENAI_API_KEY`-style secret. */
+  apiKey: string;
+  /** Optional project / org id passed through on the provider config. */
+  projectId?: string;
 }
 
 export function ProvidersTab({
@@ -48,7 +62,9 @@ export function ProvidersTab({
   onSaveKey,
   onDeleteKey,
   onTestProvider,
+  onAddCustomProvider,
 }: ProvidersTabProps) {
+  const [showAddCustom, setShowAddCustom] = useState(false);
   const configured = useMemo(() => {
     const set = new Set<string>();
     for (const p of providers) {
@@ -92,6 +108,7 @@ export function ProvidersTab({
         configured={configured}
         focusId={focusId}
         onFocus={onFocusProvider}
+        onAddCustom={() => setShowAddCustom(true)}
       />
       <ProviderPanel
         key={current.id}
@@ -102,6 +119,15 @@ export function ProvidersTab({
         onDeleteKey={onDeleteKey}
         onTestProvider={onTestProvider}
       />
+      {showAddCustom && (
+        <AddCustomProviderModal
+          onClose={() => setShowAddCustom(false)}
+          onSubmit={async (input) => {
+            await onAddCustomProvider(input);
+            setShowAddCustom(false);
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -111,11 +137,13 @@ function ProviderRail({
   configured,
   focusId,
   onFocus,
+  onAddCustom,
 }: {
   providers: ModelProviderDefinition[];
   configured: Set<string>;
   focusId: string;
   onFocus: (id: string) => void;
+  onAddCustom: () => void;
 }) {
   return (
     <div className="provider-list">
@@ -140,7 +168,11 @@ function ProviderRail({
         >
           {providers.length} providers
         </span>
-        <button className="btn btn-ghost btn-sm" style={{ paddingLeft: 6, paddingRight: 6 }}>
+        <button
+          className="btn btn-ghost btn-sm"
+          style={{ paddingLeft: 6, paddingRight: 6 }}
+          onClick={onAddCustom}
+        >
           <Plus size={12} /> Custom
         </button>
       </div>
@@ -472,6 +504,181 @@ function KeyRow({
             )}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Add Custom Provider ──────────────────────────────────────────────
+
+function AddCustomProviderModal({
+  onClose,
+  onSubmit,
+}: {
+  onClose: () => void;
+  onSubmit: (input: AddCustomProviderInput) => Promise<void>;
+}) {
+  const [name, setName] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const valid = name.trim().length > 0 && baseUrl.trim().length > 0 && apiKey.trim().length > 0;
+
+  const handleSubmit = async () => {
+    if (!valid) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        baseUrl: baseUrl.trim(),
+        apiKey: apiKey.trim(),
+        projectId: projectId.trim() || undefined,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add provider');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="drawer-backdrop"
+      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 480,
+          background: 'var(--m-bg-elev)',
+          border: '1px solid var(--m-border)',
+          borderRadius: 'var(--m-radius-lg)',
+          padding: 20,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 14,
+          }}
+        >
+          <h3 style={{ margin: 0, fontSize: 16, color: 'var(--m-text)' }}>Add custom provider</h3>
+          <button onClick={onClose} className="btn btn-ghost" style={{ width: 28, height: 28, padding: 0 }}>
+            <X size={16} />
+          </button>
+        </div>
+        <p style={{ fontSize: 12.5, color: 'var(--m-text-muted)', margin: '0 0 16px' }}>
+          Any OpenAI-compatible endpoint — vLLM, LiteLLM, LangDB, Ollama. The server probes{' '}
+          <code className="mono-text" style={{ fontSize: 11 }}>
+            GET /models
+          </code>{' '}
+          when you save.
+        </p>
+
+        <ModalField
+          label="Display name"
+          placeholder="My local cluster"
+          value={name}
+          onChange={setName}
+        />
+        <ModalField
+          label="Base URL"
+          placeholder="https://llm.acme.io/v1"
+          value={baseUrl}
+          onChange={setBaseUrl}
+          mono
+        />
+        <ModalField
+          label="API key"
+          placeholder="sk-…"
+          value={apiKey}
+          onChange={setApiKey}
+          mono
+          sensitive
+        />
+        <ModalField
+          label="Project ID"
+          placeholder="proj-…"
+          value={projectId}
+          onChange={setProjectId}
+          mono
+          optional
+        />
+
+        {error && (
+          <div style={{ color: '#FDA4AF', fontSize: 12.5, marginTop: 10 }}>{error}</div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+          <button className="btn btn-secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={!valid || submitting}
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={13} className="shimmer" /> Adding…
+              </>
+            ) : (
+              'Add provider'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ModalField({
+  label,
+  placeholder,
+  value,
+  onChange,
+  mono,
+  sensitive,
+  optional,
+}: {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  mono?: boolean;
+  sensitive?: boolean;
+  optional?: boolean;
+}) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <label
+        style={{
+          display: 'block',
+          fontSize: 12,
+          color: 'var(--m-text-muted)',
+          marginBottom: 5,
+        }}
+      >
+        {label}
+        {optional && (
+          <span style={{ color: 'var(--m-text-faint)', marginLeft: 6 }}>(optional)</span>
+        )}
+      </label>
+      <div className="input">
+        <input
+          type={sensitive ? 'password' : 'text'}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          style={{ fontFamily: mono ? 'var(--m-font-mono)' : 'inherit' }}
+        />
       </div>
     </div>
   );

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -1,0 +1,478 @@
+/**
+ * Providers tab — split-pane: provider rail (left) + selected provider's
+ * config panel (right). Configured providers sort to the top of the rail.
+ *
+ * Real wiring: `upsertSecret`, `deleteSecret`, `testProvider` come from
+ * the existing `DistriHomeClient` — pass them in as callbacks so this
+ * component stays UI-only.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Check,
+  ChevronRight,
+  Eye,
+  ExternalLink,
+  Loader2,
+  Plus,
+  Power,
+  Trash2,
+  X,
+} from 'lucide-react';
+import type {
+  ModelProviderDefinition,
+  ProviderKeyDefinition,
+  Secret,
+} from '../../DistriHomeClient';
+import { CAPABILITY_META, providerDocs, providerMonogram } from './data';
+import { CapPill, MonoChip } from './primitives';
+
+interface ProvidersTabProps {
+  providers: ModelProviderDefinition[];
+  secrets: Secret[];
+  focusProviderId?: string;
+  onFocusProvider: (providerId: string) => void;
+  /** Save (upsert) a single key. */
+  onSaveKey: (providerId: string, key: string, value: string) => Promise<void>;
+  /** Delete a stored secret. */
+  onDeleteKey: (key: string) => Promise<void>;
+  /** Test a provider's connection via `POST /v1/providers/test`. */
+  onTestProvider: (providerId: string) => Promise<{ ok: boolean; detail: string }>;
+}
+
+export function ProvidersTab({
+  providers,
+  secrets,
+  focusProviderId,
+  onFocusProvider,
+  onSaveKey,
+  onDeleteKey,
+  onTestProvider,
+}: ProvidersTabProps) {
+  const configured = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of providers) {
+      const required = p.keys.filter((k) => k.required !== false);
+      const allPresent = required.every((k) => secrets.some((s) => s.key === k.key));
+      if (required.length > 0 && allPresent) set.add(p.id);
+    }
+    return set;
+  }, [providers, secrets]);
+
+  const focusId = focusProviderId
+    ?? providers.find((p) => configured.has(p.id))?.id
+    ?? providers[0]?.id
+    ?? '';
+  const current = providers.find((p) => p.id === focusId) ?? providers[0];
+
+  // Sort configured first, then catalog order.
+  const sorted = useMemo(() => {
+    const list = [...providers];
+    list.sort((a, b) => {
+      const ac = configured.has(a.id) ? 0 : 1;
+      const bc = configured.has(b.id) ? 0 : 1;
+      if (ac !== bc) return ac - bc;
+      return providers.indexOf(a) - providers.indexOf(b);
+    });
+    return list;
+  }, [providers, configured]);
+
+  if (!current) {
+    return (
+      <div className="provider-panel" style={{ padding: 24 }}>
+        No providers available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="providers-grid">
+      <ProviderRail
+        providers={sorted}
+        configured={configured}
+        focusId={focusId}
+        onFocus={onFocusProvider}
+      />
+      <ProviderPanel
+        key={current.id}
+        provider={current}
+        secrets={secrets}
+        configured={configured.has(current.id)}
+        onSaveKey={onSaveKey}
+        onDeleteKey={onDeleteKey}
+        onTestProvider={onTestProvider}
+      />
+    </div>
+  );
+}
+
+function ProviderRail({
+  providers,
+  configured,
+  focusId,
+  onFocus,
+}: {
+  providers: ModelProviderDefinition[];
+  configured: Set<string>;
+  focusId: string;
+  onFocus: (id: string) => void;
+}) {
+  return (
+    <div className="provider-list">
+      <div
+        style={{
+          padding: '6px 10px 10px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: '1px solid var(--m-border-soft)',
+          marginBottom: 6,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: 'var(--m-text-faint)',
+            fontWeight: 600,
+          }}
+        >
+          {providers.length} providers
+        </span>
+        <button className="btn btn-ghost btn-sm" style={{ paddingLeft: 6, paddingRight: 6 }}>
+          <Plus size={12} /> Custom
+        </button>
+      </div>
+      {providers.map((p) => {
+        const conf = configured.has(p.id);
+        const active = p.id === focusId;
+        return (
+          <div
+            key={p.id}
+            className={`prov-row ${active ? 'active' : ''}`}
+            onClick={() => onFocus(p.id)}
+          >
+            <span className="mono lg" style={{ background: 'rgba(255,255,255,.04)' }}>
+              {providerMonogram(p.id)}
+            </span>
+            <div>
+              <div className="label">{p.label}</div>
+              <div className="sub">
+                <span className={`status-dot ${conf ? 'ok' : ''}`} />
+                <span>{conf ? 'Configured' : 'Not configured'}</span>
+                <span style={{ color: 'var(--m-text-faint)' }}>· {p.models.length} models</span>
+              </div>
+            </div>
+            <ChevronRight size={14} style={{ color: 'var(--m-text-faint)' }} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProviderPanel({
+  provider,
+  secrets,
+  configured,
+  onSaveKey,
+  onDeleteKey,
+  onTestProvider,
+}: {
+  provider: ModelProviderDefinition;
+  secrets: Secret[];
+  configured: boolean;
+  onSaveKey: (providerId: string, key: string, value: string) => Promise<void>;
+  onDeleteKey: (key: string) => Promise<void>;
+  onTestProvider: (providerId: string) => Promise<{ ok: boolean; detail: string }>;
+}) {
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; detail: string } | null>(null);
+  const [revealed, setRevealed] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setFieldValues({});
+    setTestResult(null);
+    setTesting(false);
+    setRevealed(new Set());
+  }, [provider.id]);
+
+  const caps = useMemo(() => {
+    const out = new Set<string>();
+    for (const m of provider.models) out.add(m.capability);
+    return Array.from(out);
+  }, [provider]);
+
+  const docs = providerDocs(provider.id);
+
+  const handleSaveOne = async (key: string) => {
+    const value = fieldValues[key]?.trim();
+    if (!value) return;
+    setSavingKey(key);
+    try {
+      await onSaveKey(provider.id, key, value);
+      setFieldValues((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await onTestProvider(provider.id);
+      setTestResult(result);
+    } catch (err) {
+      setTestResult({ ok: false, detail: err instanceof Error ? err.message : 'Test failed' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="provider-panel">
+      <div className="head">
+        <span className="mono lg" style={{ width: 44, height: 44, fontSize: 14 }}>
+          {providerMonogram(provider.id)}
+        </span>
+        <div>
+          <h2>{provider.label}</h2>
+          <div className="sub">
+            <span style={{ color: configured ? '#6EE7B7' : 'var(--m-text-faint)' }}>
+              {configured ? '● Configured' : '○ Not configured'}
+            </span>
+            <span style={{ margin: '0 8px', color: 'var(--m-text-faint)' }}>·</span>
+            {provider.models.length} models · {caps.map((c) => CAPABILITY_META[c as 'completion']?.short).join(', ')}
+            {docs && (
+              <>
+                <span style={{ margin: '0 8px', color: 'var(--m-text-faint)' }}>·</span>
+                <a
+                  href={docs}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ color: 'var(--m-brand-soft)', textDecoration: 'none' }}
+                >
+                  Docs <ExternalLink size={11} style={{ display: 'inline', marginLeft: 2 }} />
+                </a>
+              </>
+            )}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-secondary btn-sm" onClick={handleTest} disabled={testing}>
+            {testing ? (
+              <>
+                <Loader2 size={12} className="shimmer" /> Testing…
+              </>
+            ) : (
+              <>
+                <Power size={12} /> Test connection
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="body">
+        <div>
+          <p className="section-title">Capabilities</p>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {caps.map((c) => (
+              <CapPill key={c} type={c as 'completion'} />
+            ))}
+          </div>
+        </div>
+
+        {testResult && (
+          <div
+            className="testbar"
+            style={{
+              borderColor: testResult.ok ? 'rgba(16,185,129,.32)' : 'rgba(244,63,94,.32)',
+              background: testResult.ok ? 'rgba(16,185,129,.06)' : 'rgba(244,63,94,.06)',
+            }}
+          >
+            <span className={`status ${testResult.ok ? 'ok' : 'bad'}`}>
+              {testResult.ok ? <Check size={14} /> : <X size={14} />}
+              {testResult.detail}
+            </span>
+            <span style={{ flex: 1 }} />
+            <button className="btn btn-ghost btn-sm" onClick={() => setTestResult(null)}>
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        <div>
+          <p className="section-title">Credentials</p>
+          <div>
+            {provider.keys.map((k) => (
+              <KeyRow
+                key={k.key}
+                k={k}
+                saved={secrets.find((s) => s.key === k.key)}
+                draftValue={fieldValues[k.key]}
+                onDraftChange={(v) =>
+                  setFieldValues((prev) => ({ ...prev, [k.key]: v }))
+                }
+                onSave={() => handleSaveOne(k.key)}
+                onDelete={async () => onDeleteKey(k.key)}
+                saving={savingKey === k.key}
+                revealed={revealed.has(k.key)}
+                onToggleReveal={() =>
+                  setRevealed((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(k.key)) next.delete(k.key);
+                    else next.add(k.key);
+                    return next;
+                  })
+                }
+              />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 }}>
+            <p className="section-title" style={{ margin: 0 }}>
+              Models
+            </p>
+            <span style={{ fontSize: 11.5, color: 'var(--m-text-faint)' }}>
+              {provider.models.length} available
+            </span>
+          </div>
+          <div
+            style={{
+              border: '1px solid var(--m-border)',
+              borderRadius: 'var(--m-radius-md)',
+              overflow: 'hidden',
+            }}
+          >
+            {provider.models.map((m, idx) => (
+              <div
+                key={m.id}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr auto auto',
+                  gap: 14,
+                  alignItems: 'center',
+                  padding: '10px 14px',
+                  borderTop: idx === 0 ? '0' : '1px solid var(--m-border-soft)',
+                }}
+              >
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 500 }}>{m.name}</div>
+                  <div
+                    className="mono-text"
+                    style={{ fontSize: 11, color: 'var(--m-text-faint)', marginTop: 1 }}
+                  >
+                    {provider.id}/{m.id}
+                  </div>
+                </div>
+                <CapPill type={m.capability} />
+                <MonoChip providerId={provider.id} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KeyRow({
+  k,
+  saved,
+  draftValue,
+  onDraftChange,
+  onSave,
+  onDelete,
+  saving,
+  revealed,
+  onToggleReveal,
+}: {
+  k: ProviderKeyDefinition;
+  saved?: Secret;
+  draftValue?: string;
+  onDraftChange: (value: string) => void;
+  onSave: () => void;
+  onDelete: () => Promise<void>;
+  saving: boolean;
+  revealed: boolean;
+  onToggleReveal: () => void;
+}) {
+  const hasDraft = !!draftValue?.trim() && !saved;
+  return (
+    <div className="field-row">
+      <div>
+        <div className="lbl">
+          {k.label}
+          {!k.required && (
+            <span style={{ color: 'var(--m-text-faint)', fontWeight: 400, marginLeft: 6 }}>
+              (optional)
+            </span>
+          )}
+        </div>
+        <div className="desc">
+          <code className="mono-text" style={{ fontSize: 11, color: 'var(--m-text-faint)' }}>
+            {k.key}
+          </code>
+        </div>
+      </div>
+      <div>
+        <div className={`input ${saved ? 'saved' : ''}`}>
+          <input
+            type="text"
+            value={
+              saved
+                ? revealed && saved.masked_value
+                  ? saved.masked_value
+                  : '••••••••••••'
+                : (draftValue ?? '')
+            }
+            placeholder={k.placeholder}
+            onChange={(e) => onDraftChange(e.target.value)}
+            readOnly={!!saved}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && hasDraft) onSave();
+            }}
+          />
+          <div className="actions">
+            {saved && k.sensitive && saved.masked_value && (
+              <button title={revealed ? 'Hide' : 'Reveal mask'} onClick={onToggleReveal}>
+                <Eye size={13} />
+              </button>
+            )}
+            {saved && (
+              <button title="Remove" onClick={() => void onDelete()}>
+                <Trash2 size={13} />
+              </button>
+            )}
+            {hasDraft && (
+              <button
+                title="Save"
+                onClick={onSave}
+                disabled={saving}
+                style={{ color: 'var(--m-brand-soft)' }}
+              >
+                {saving ? <Loader2 size={13} className="shimmer" /> : <Check size={13} />}
+              </button>
+            )}
+            {hasDraft && (
+              <button title="Clear" onClick={() => onDraftChange('')}>
+                <X size={13} />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/home/src/components/models/VoicePlayground.tsx
+++ b/packages/home/src/components/models/VoicePlayground.tsx
@@ -1,0 +1,451 @@
+/**
+ * Voice (TTS) playground. Two-column layout: text/voices on the left,
+ * params on the right. Calls `homeClient.generateSpeech`, decodes the
+ * returned audio bytes into a Blob URL, and feeds them to an `<audio>`
+ * element that the play/pause button controls.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Download,
+  Loader2,
+  Pause,
+  Play,
+  PlayCircle,
+  Speaker,
+} from 'lucide-react';
+import type {
+  DistriHomeClient,
+  ModelProviderDefinition,
+  TtsVoiceInfo,
+} from '../../DistriHomeClient';
+import { CapPill } from './primitives';
+
+interface VoicePlaygroundProps {
+  homeClient: DistriHomeClient;
+  providers: ModelProviderDefinition[];
+  configured: Set<string>;
+  initialProviderId?: string;
+  initialModelId?: string;
+  onBack: () => void;
+}
+
+interface TtsRow {
+  providerId: string;
+  providerLabel: string;
+  modelId: string;
+  modelName: string;
+  voices: TtsVoiceInfo[];
+  formats: string[];
+}
+
+export function VoicePlayground({
+  homeClient,
+  providers,
+  configured,
+  initialProviderId,
+  initialModelId,
+  onBack,
+}: VoicePlaygroundProps) {
+  const ttsModels = useMemo<TtsRow[]>(() => {
+    const out: TtsRow[] = [];
+    for (const p of providers) {
+      for (const m of p.models) {
+        if (m.capability === 'tts') {
+          out.push({
+            providerId: p.id,
+            providerLabel: p.label,
+            modelId: m.id,
+            modelName: m.name,
+            voices: m.voices ?? [],
+            formats: m.formats ?? ['mp3'],
+          });
+        }
+      }
+    }
+    return out;
+  }, [providers]);
+
+  const initial = ttsModels.find(
+    (m) => m.providerId === initialProviderId && m.modelId === initialModelId,
+  ) ?? ttsModels[0];
+  const [selectedId, setSelectedId] = useState(
+    initial ? `${initial.providerId}/${initial.modelId}` : '',
+  );
+
+  const selected = useMemo(() => {
+    const [pid, mid] = selectedId.split('/');
+    return ttsModels.find((m) => m.providerId === pid && m.modelId === mid) ?? ttsModels[0];
+  }, [selectedId, ttsModels]);
+
+  const [text, setText] = useState(
+    'Welcome to Distri Cloud. Your agents are running smoothly today — six active threads, no errors in the last hour.',
+  );
+  const [voice, setVoice] = useState<string>(selected?.voices[0]?.id ?? 'alloy');
+  const [format, setFormat] = useState<string>(selected?.formats[0] ?? 'mp3');
+  const [speed, setSpeed] = useState<number>(1.0);
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [contentType, setContentType] = useState<string>('audio/mpeg');
+  const [generating, setGenerating] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Reset voice + format when the selected model changes.
+  useEffect(() => {
+    if (!selected) return;
+    if (!selected.voices.find((v) => v.id === voice)) {
+      setVoice(selected.voices[0]?.id ?? 'alloy');
+    }
+    if (!selected.formats.includes(format)) {
+      setFormat(selected.formats[0] ?? 'mp3');
+    }
+  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Free the old blob URL when we replace it.
+  useEffect(() => {
+    return () => {
+      if (audioUrl) URL.revokeObjectURL(audioUrl);
+    };
+  }, [audioUrl]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!selected || !text.trim()) return;
+    setGenerating(true);
+    setError(null);
+    setPlaying(false);
+    try {
+      const response = await homeClient.generateSpeech({
+        input: text,
+        model: selected.modelId,
+        voice,
+        provider: selected.providerId,
+        response_format: format,
+        speed,
+      });
+      const blob = new Blob([response.audio], { type: response.contentType });
+      const url = URL.createObjectURL(blob);
+      if (audioUrl) URL.revokeObjectURL(audioUrl);
+      setAudioUrl(url);
+      setContentType(response.contentType);
+      // Autoplay
+      setTimeout(() => {
+        if (audioRef.current) {
+          audioRef.current.src = url;
+          audioRef.current.play().catch(() => {});
+          setPlaying(true);
+        }
+      }, 50);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'TTS generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  }, [homeClient, selected, text, voice, format, speed, audioUrl]);
+
+  const togglePlay = () => {
+    if (!audioRef.current || !audioUrl) return;
+    if (playing) {
+      audioRef.current.pause();
+      setPlaying(false);
+    } else {
+      audioRef.current.play().catch(() => {});
+      setPlaying(true);
+    }
+  };
+
+  const downloadAudio = () => {
+    if (!audioUrl) return;
+    const a = document.createElement('a');
+    a.href = audioUrl;
+    a.download = `tts.${format}`;
+    a.click();
+  };
+
+  if (ttsModels.length === 0) {
+    return (
+      <div style={{ padding: 24 }}>
+        <button className="btn btn-ghost btn-sm" onClick={onBack}>
+          <ArrowLeft size={13} /> Catalog
+        </button>
+        <div style={{ marginTop: 24, color: 'var(--m-text-muted)' }}>
+          No TTS-capable models in the catalog. Configure a provider first.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+        <button className="btn btn-ghost btn-sm" onClick={onBack}>
+          <ArrowLeft size={13} /> Catalog
+        </button>
+        <span style={{ color: 'var(--m-text-faint)' }}>/</span>
+        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>Text-to-speech playground</h2>
+        <span style={{ flex: 1 }} />
+        <select
+          className="select"
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          style={{
+            background: 'rgba(255,255,255,.02)',
+            border: '1px solid var(--m-border)',
+            color: 'var(--m-text)',
+            borderRadius: 'var(--m-radius-md)',
+            padding: '7px 10px',
+            fontSize: 13,
+            minWidth: 280,
+            fontFamily: 'var(--m-font-mono)',
+          }}
+        >
+          {ttsModels.map((m) => {
+            const id = `${m.providerId}/${m.modelId}`;
+            const ok = configured.has(m.providerId);
+            return (
+              <option key={id} value={id} disabled={!ok}>
+                {id}
+                {ok ? '' : '  (not configured)'}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+
+      <div className="pg">
+        <div className="surface">
+          <div
+            style={{
+              padding: '14px 18px',
+              borderBottom: '1px solid var(--m-border-soft)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              fontSize: 12.5,
+              color: 'var(--m-text-muted)',
+            }}
+          >
+            <CapPill type="tts" />
+            <span className="mono-text">{selectedId}</span>
+            <span style={{ flex: 1 }} />
+            <span>
+              {text.length} chars · {format.toUpperCase()}
+            </span>
+          </div>
+
+          <div style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <div>
+              <div
+                style={{
+                  fontSize: 11,
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                  color: 'var(--m-text-faint)',
+                  fontWeight: 600,
+                  marginBottom: 8,
+                }}
+              >
+                Text to synthesise
+              </div>
+              <textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                style={{
+                  width: '100%',
+                  minHeight: 120,
+                  padding: 14,
+                  background: 'rgba(255,255,255,.02)',
+                  border: '1px solid var(--m-border)',
+                  borderRadius: 'var(--m-radius-md)',
+                  color: 'var(--m-text)',
+                  fontSize: 14.5,
+                  lineHeight: 1.55,
+                  resize: 'vertical',
+                  outline: 0,
+                  fontFamily: 'inherit',
+                }}
+              />
+            </div>
+
+            <div
+              style={{
+                padding: 16,
+                border: '1px solid var(--m-border)',
+                borderRadius: 'var(--m-radius-md)',
+                display: 'grid',
+                gridTemplateColumns: '46px 1fr auto auto',
+                gap: 14,
+                alignItems: 'center',
+                background: 'var(--m-bg-sunk)',
+              }}
+            >
+              <button
+                className="btn btn-primary"
+                style={{ width: 46, height: 46, borderRadius: '50%', padding: 0 }}
+                onClick={togglePlay}
+                disabled={!audioUrl || generating}
+              >
+                {playing ? <Pause size={18} /> : <Play size={18} />}
+              </button>
+              <div>
+                <audio
+                  ref={audioRef}
+                  onEnded={() => setPlaying(false)}
+                  onPause={() => setPlaying(false)}
+                  style={{ width: '100%' }}
+                  controls={false}
+                />
+                <div
+                  style={{
+                    fontFamily: 'var(--m-font-mono)',
+                    fontSize: 11,
+                    color: 'var(--m-text-faint)',
+                  }}
+                >
+                  {audioUrl
+                    ? `${contentType} · ${voice}`
+                    : generating
+                    ? 'Generating…'
+                    : 'Press Generate to synthesise'}
+                </div>
+              </div>
+              <button
+                className="btn btn-primary"
+                onClick={handleGenerate}
+                disabled={generating || !text.trim()}
+              >
+                {generating ? (
+                  <>
+                    <Loader2 size={13} className="shimmer" /> Generating…
+                  </>
+                ) : (
+                  <>
+                    <Speaker size={13} /> Generate
+                  </>
+                )}
+              </button>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={downloadAudio}
+                disabled={!audioUrl}
+              >
+                <Download size={12} /> Download
+              </button>
+            </div>
+
+            {error && (
+              <div style={{ color: '#FDA4AF', fontSize: 12.5 }}>{error}</div>
+            )}
+
+            {selected && selected.voices.length > 0 && (
+              <div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    letterSpacing: '0.12em',
+                    textTransform: 'uppercase',
+                    color: 'var(--m-text-faint)',
+                    fontWeight: 600,
+                    marginBottom: 8,
+                  }}
+                >
+                  Voices · {selected.voices.length}
+                </div>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
+                  {selected.voices.map((v) => (
+                    <div
+                      key={v.id}
+                      className={`voice-card ${voice === v.id ? 'active' : ''}`}
+                      onClick={() => setVoice(v.id)}
+                    >
+                      <div>
+                        <div className="name">{v.name}</div>
+                        {v.description && <div className="desc">{v.description}</div>}
+                      </div>
+                      <PlayCircle size={16} style={{ color: 'var(--m-text-faint)' }} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="surface params">
+          <ParamSection title="Voice">
+            <div className="mono-text" style={{ fontSize: 12, color: 'var(--m-text)' }}>
+              {voice}
+            </div>
+          </ParamSection>
+          <ParamSlider
+            label="Speed"
+            value={speed}
+            setValue={setSpeed}
+            min={0.25}
+            max={4.0}
+            step={0.05}
+          />
+          <ParamSection title="Format">
+            <select
+              className="select"
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+            >
+              {selected?.formats.map((f) => (
+                <option key={f} value={f}>
+                  {f.toUpperCase()}
+                </option>
+              ))}
+            </select>
+          </ParamSection>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ParamSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="param">
+      <div className="lbl">
+        <span>{title}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ParamSlider({
+  label,
+  value,
+  setValue,
+  min,
+  max,
+  step,
+}: {
+  label: string;
+  value: number;
+  setValue: (v: number) => void;
+  min: number;
+  max: number;
+  step: number;
+}) {
+  return (
+    <div className="param">
+      <div className="lbl">
+        <span>{label}</span>
+        <span className="v">{value.toFixed(2)}</span>
+      </div>
+      <input
+        className="slider"
+        type="range"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(e) => setValue(Number(e.target.value))}
+      />
+    </div>
+  );
+}

--- a/packages/home/src/components/models/data.ts
+++ b/packages/home/src/components/models/data.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared metadata for the redesigned models settings UI.
+ *
+ * - Capability colors / labels (the colored pills + chips).
+ * - Per-provider monograms (the two-letter chips used across the
+ *   catalog, providers split-pane, drawer header, and playgrounds).
+ *
+ * Provider extras (monogram, accent, docs) live here rather than in
+ * the catalog so we can decorate any provider id without depending
+ * on backend changes. Unknown providers fall back to a derived
+ * monogram (first two letters of the id, uppercased).
+ */
+
+import type { ModelCapability } from '../../DistriHomeClient';
+
+export interface CapabilityMeta {
+  label: string;
+  short: string;
+}
+
+export const CAPABILITY_META: Record<ModelCapability, CapabilityMeta> = {
+  completion: { label: 'Completion', short: 'Completion' },
+  tts: { label: 'Text to speech', short: 'TTS' },
+  stt: { label: 'Speech to text', short: 'STT' },
+  image: { label: 'Image', short: 'Image' },
+};
+
+export const ALL_CAPABILITIES: ModelCapability[] = ['completion', 'tts', 'stt', 'image'];
+
+interface ProviderExtras {
+  monogram: string;
+  accent: string;
+  docs?: string;
+}
+
+const PROVIDER_EXTRAS: Record<string, ProviderExtras> = {
+  openai: { monogram: 'OA', accent: '#10A37F', docs: 'https://platform.openai.com/docs' },
+  anthropic: { monogram: 'AN', accent: '#D97757', docs: 'https://docs.anthropic.com' },
+  gemini: { monogram: 'GG', accent: '#4285F4', docs: 'https://ai.google.dev' },
+  google_gemini: { monogram: 'GG', accent: '#4285F4', docs: 'https://ai.google.dev' },
+  azure_ai_foundry: { monogram: 'AZ', accent: '#0078D4', docs: 'https://learn.microsoft.com/azure/ai-foundry' },
+  alibaba_cloud: { monogram: 'AC', accent: '#FF6A00', docs: 'https://www.alibabacloud.com/help/en/model-studio' },
+  aws_bedrock: { monogram: 'AW', accent: '#FF9900', docs: 'https://docs.aws.amazon.com/bedrock' },
+  google_vertex: { monogram: 'GV', accent: '#4285F4', docs: 'https://cloud.google.com/vertex-ai' },
+  elevenlabs: { monogram: 'EL', accent: '#000000', docs: 'https://elevenlabs.io/docs' },
+  fal_ai: { monogram: 'FA', accent: '#5D3DFD', docs: 'https://fal.ai/docs' },
+  xai: { monogram: 'XA', accent: '#1DA1F2' },
+  mistral: { monogram: 'MI', accent: '#FF7000' },
+  deepseek: { monogram: 'DS', accent: '#4D6BFE' },
+  fireworks: { monogram: 'FW', accent: '#5D3DFD' },
+  replicate: { monogram: 'RP', accent: '#EA580C' },
+};
+
+export function providerMonogram(providerId: string): string {
+  return PROVIDER_EXTRAS[providerId]?.monogram ?? providerId.slice(0, 2).toUpperCase();
+}
+
+export function providerAccent(providerId: string): string {
+  return PROVIDER_EXTRAS[providerId]?.accent ?? '#4FB5C3';
+}
+
+export function providerDocs(providerId: string): string | undefined {
+  return PROVIDER_EXTRAS[providerId]?.docs;
+}
+
+export function formatContext(tokens?: number): string {
+  if (!tokens) return '—';
+  if (tokens >= 1_000_000) {
+    const v = tokens / 1_000_000;
+    return (v % 1 === 0 ? v : v.toFixed(1)) + 'M';
+  }
+  if (tokens >= 1_000) {
+    const v = tokens / 1_000;
+    return (v % 1 === 0 ? v : v.toFixed(1)) + 'K';
+  }
+  return String(tokens);
+}

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -45,10 +45,8 @@
 /* ── Page chrome ───────────────────────────────────────────────────── */
 .models-shell .page {
   padding: 20px 28px 56px;
-  max-width: 1680px;
   width: 100%;
   box-sizing: border-box;
-  margin: 0 auto;
 }
 
 /* Unified top toolbar — adapts to route (catalog/providers vs playground). */

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -11,14 +11,16 @@
  * ============================================================ */
 
 .models-shell {
-  /* This wrapper exists only to scope the design tokens and the dark
-     palette used across the Models page. It does NOT take responsibility
-     for layout — the parent (AppLayout's <main>) controls width, height,
-     and overflow. Don't add max-width / overflow / min-height here; that
-     was fighting the flex parent and producing both an inner scroll and
-     a sub-viewport width. */
+  /* The wrapper scopes the dark tokens AND owns the scroll. The parent
+     <main> in AppLayout is `overflow-hidden` so it can't scroll — if the
+     shell doesn't, the content past the viewport is just hidden. Taking
+     the parent's full height with `height: 100%` + `overflow-y: auto`
+     makes this the scroll container. */
   width: 100%;
+  height: 100%;
   flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
   /* Local tokens — these override only inside the shell. Use literal
      hexes rather than `var(--background)` etc.; shadcn's variables
      ship as raw HSL components and resolve to invalid color values
@@ -697,13 +699,15 @@
   font-size: 11.5px; color: var(--m-text-faint); margin-top: 2px;
 }
 
-/* Image */
+/* Image — tiles centre-wrap in the canvas so a single n=1 generation
+   doesn't sit left-aligned in a 2-column grid. */
 .models-shell .image-canvas {
   flex: 1;
   background:
     linear-gradient(135deg, transparent 24%, rgba(255,255,255,.014) 25%, rgba(255,255,255,.014) 26%, transparent 27%) 0 0 / 24px 24px,
     var(--m-bg-sunk);
-  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+  display: flex; flex-wrap: wrap; gap: 12px;
+  justify-content: center; align-content: flex-start;
   padding: 18px;
 }
 .models-shell .image-tile {
@@ -711,6 +715,11 @@
   background: linear-gradient(135deg, #1d242c, #0e1216);
   aspect-ratio: 1;
   position: relative; overflow: hidden;
+  /* Two tiles per row up to a sensible max width; a single tile lands
+     centred at its max size rather than stretching across the canvas. */
+  flex: 1 1 calc(50% - 6px);
+  max-width: 560px;
+  min-width: 240px;
 }
 .models-shell .image-tile img { width: 100%; height: 100%; object-fit: cover; }
 .models-shell .image-tile .meta {

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -17,11 +17,16 @@
   max-width: 100vw;
   overflow-x: hidden;
   min-width: 0;
-  /* Local tokens — these override only inside the shell. */
+  /* Local tokens — these override only inside the shell.
+     `--m-bg` was previously `var(--background, #121418)` to inherit
+     from shadcn, but shadcn's `--background` is raw HSL components
+     (e.g. `222 47% 11%`), not a color — `var(--background)` evaluates
+     to an invalid value and the drawer / page background fell through
+     to transparent. Use a literal hex. */
   --m-brand: #007C91;
   --m-brand-soft: #4FB5C3;
   --m-brand-deep: #005B6B;
-  --m-bg: var(--background, #121418);
+  --m-bg: #121418;
   --m-bg-elev: #1A1D23;
   --m-bg-sunk: #0C0E11;
   --m-border: #2A2F3A;

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -163,15 +163,11 @@
   background: var(--m-bg-elev);
   border: 1px solid var(--m-border);
   border-radius: var(--m-radius-md);
-  position: relative;
-  cursor: pointer;
-  transition: border-color .12s ease;
-  /* Allow the inner `.value` text-overflow:ellipsis to actually clip —
-     flex items default to min-width:auto which lets the long mono
-     `provider/model` ids push the grid wider than its column. */
+  /* Purely informational — there's no "Change" control behind the card.
+     Defaults are toggled via the per-row CheckCircle in the catalog's
+     Default column. */
   min-width: 0;
 }
-.models-shell .default-card:hover { border-color: var(--m-brand-deep); }
 .models-shell .default-card .row1 { display: flex; align-items: center; gap: 8px; }
 .models-shell .default-card .cap-label {
   font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase;
@@ -185,12 +181,6 @@
 .models-shell .default-card .value.empty {
   font-family: inherit; color: var(--m-text-faint); font-style: italic;
 }
-.models-shell .default-card .change {
-  position: absolute; right: 10px; top: 10px;
-  font-size: 11px; color: var(--m-text-faint);
-  opacity: 0; transition: opacity .12s ease;
-}
-.models-shell .default-card:hover .change { opacity: 1; color: var(--m-brand-soft); }
 
 /* ── Capability chips ──────────────────────────────────────────────── */
 .models-shell .toolbar {

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -43,7 +43,80 @@
 .models-shell button { font: inherit; color: inherit; background: none; border: 0; padding: 0; cursor: pointer; }
 
 /* ── Page chrome ───────────────────────────────────────────────────── */
-.models-shell .page { padding: 20px 28px 56px; max-width: 1480px; }
+.models-shell .page {
+  padding: 20px 28px 56px;
+  max-width: 1680px;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+/* Unified top toolbar — adapts to route (catalog/providers vs playground). */
+.models-shell .toolbar-row {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 20px;
+}
+.models-shell .tb-sep {
+  width: 1px; height: 22px; background: var(--m-border); margin: 0 4px;
+}
+.models-shell .subtab-count {
+  font-family: var(--m-font-mono); font-size: 10.5px;
+  color: var(--m-text-faint);
+  background: rgba(255,255,255,.05);
+  padding: 1px 6px; border-radius: 4px;
+  margin-left: 2px;
+}
+.models-shell .subtab.back {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 12px 7px 10px;
+  border-radius: var(--m-radius-md);
+  font-size: 13px; font-weight: 500;
+  color: var(--m-text-muted);
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+}
+.models-shell .subtab.back:hover { color: var(--m-text); background: rgba(255,255,255,.04); }
+
+.models-shell .cap-switcher {
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 3px;
+  border-radius: var(--m-radius-md);
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+}
+.models-shell .cap-switch {
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12.5px; font-weight: 500;
+  color: var(--m-text-muted);
+}
+.models-shell .cap-switch:hover { color: var(--m-text); }
+.models-shell .cap-switch.active {
+  background: var(--m-bg);
+  color: var(--m-text);
+  box-shadow: 0 1px 0 rgba(255,255,255,.04) inset, 0 1px 2px rgba(0,0,0,.3);
+}
+
+.models-shell .pg-model-picker {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 0 6px 0 12px;
+  border-radius: var(--m-radius-md);
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+  height: 34px;
+}
+.models-shell .pg-model-picker .lbl {
+  font-size: 11px; letter-spacing: 0.10em; text-transform: uppercase;
+  color: var(--m-text-faint); font-weight: 600;
+}
+.models-shell .pg-model-picker select {
+  background: transparent; border: 0; outline: 0;
+  color: var(--m-text);
+  font-family: var(--m-font-mono); font-size: 12.5px;
+  padding: 4px 6px; cursor: pointer;
+  min-width: 280px;
+}
+.models-shell .pg-model-picker select option { background: var(--m-bg-elev); color: var(--m-text); }
 
 .models-shell .subtabs {
   display: inline-flex; align-items: center; gap: 2px;

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -11,18 +11,18 @@
  * ============================================================ */
 
 .models-shell {
-  /* Stop any inner grid blowout from forcing the whole page into a
-     horizontal scroll. min-width:0 lets descendants shrink below their
-     intrinsic content width when CSS Grid asks them to. */
-  max-width: 100vw;
-  overflow-x: hidden;
-  min-width: 0;
-  /* Local tokens — these override only inside the shell.
-     `--m-bg` was previously `var(--background, #121418)` to inherit
-     from shadcn, but shadcn's `--background` is raw HSL components
-     (e.g. `222 47% 11%`), not a color — `var(--background)` evaluates
-     to an invalid value and the drawer / page background fell through
-     to transparent. Use a literal hex. */
+  /* This wrapper exists only to scope the design tokens and the dark
+     palette used across the Models page. It does NOT take responsibility
+     for layout — the parent (AppLayout's <main>) controls width, height,
+     and overflow. Don't add max-width / overflow / min-height here; that
+     was fighting the flex parent and producing both an inner scroll and
+     a sub-viewport width. */
+  width: 100%;
+  flex: 1;
+  /* Local tokens — these override only inside the shell. Use literal
+     hexes rather than `var(--background)` etc.; shadcn's variables
+     ship as raw HSL components and resolve to invalid color values
+     when used bare. */
   --m-brand: #007C91;
   --m-brand-soft: #4FB5C3;
   --m-brand-deep: #005B6B;
@@ -46,7 +46,6 @@
   background: var(--m-bg);
   color: var(--m-text);
   font-feature-settings: "ss01","cv11";
-  min-height: 100%;
 }
 .models-shell *,
 .models-shell *::before,

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -717,3 +717,134 @@
 .models-shell .mono-text { font-family: var(--m-font-mono); }
 .models-shell .muted { color: var(--m-text-muted); }
 .models-shell .faint { color: var(--m-text-faint); }
+
+/* ── Mobile (≤768px) ───────────────────────────────────────────────
+ *
+ * The desktop grids collapse:
+ *   - the 4-up default-model strip → 2×2,
+ *   - the dense catalog table → one card-style row per model with the
+ *     numeric columns hidden (model name + capability pill + actions
+ *     stay; pricing is reachable via the detail drawer),
+ *   - the providers split-pane → single column (rail above, panel below),
+ *   - the playground 2-col → stacked surface + params,
+ *   - the drawer + modals → full viewport width.
+ */
+@media (max-width: 768px) {
+  .models-shell .page { padding: 12px 14px 40px; }
+
+  /* Toolbar wraps. Sub-tabs stay first, Playground button drops onto its
+     own line on the narrowest widths. */
+  .models-shell .toolbar-row { flex-wrap: wrap; gap: 8px; margin-bottom: 14px; }
+  .models-shell .toolbar { flex-wrap: wrap; gap: 8px; }
+  .models-shell .search { min-width: 0; flex: 1 1 100%; }
+
+  /* Capability switcher / cap-chips can scroll horizontally rather than wrap. */
+  .models-shell .cap-chips,
+  .models-shell .cap-switcher {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .models-shell .cap-chips::-webkit-scrollbar,
+  .models-shell .cap-switcher::-webkit-scrollbar { display: none; }
+  .models-shell .cap-chip { white-space: nowrap; flex-shrink: 0; }
+
+  /* Default-model strip: 4 → 2 columns. */
+  .models-shell .defaults {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+
+  /* Catalog table → card list. The header row disappears, and each model
+     row collapses to: monogram + name (with cap pill stacked) on the
+     left, row actions on the right. Numeric columns are hidden — users
+     tap into the detail drawer for pricing. */
+  .models-shell .cat-head { display: none; }
+  .models-shell .cat-cols-completion,
+  .models-shell .cat-cols-voice,
+  .models-shell .cat-cols-image {
+    grid-template-columns: 1fr auto;
+    column-gap: 10px;
+    row-gap: 4px;
+    padding: 10px 14px;
+  }
+  /* Show only the model cell, capability pill, and the row-actions
+     buttons. Everything else (context / price / cached / default)
+     collapses to nothing on mobile. */
+  .models-shell .cat-row > * { display: none; }
+  .models-shell .cat-row > .model { display: grid; grid-column: 1 / 2; }
+  .models-shell .cat-row > div:nth-child(2) {
+    display: inline-flex; align-items: center; justify-self: end; grid-column: 2 / 3; grid-row: 1;
+  }
+  .models-shell .cat-row > .row-actions {
+    display: flex; grid-column: 1 / -1; justify-self: end; opacity: 1;
+  }
+  .models-shell .cat-row > .row-actions button { opacity: 1; }
+
+  /* Provider group header — shrink the right-side chips. */
+  .models-shell .cat-provider {
+    grid-template-columns: 22px 1fr auto;
+    column-gap: 8px;
+    padding: 9px 14px;
+  }
+  .models-shell .cat-provider .name { font-size: 11px; }
+  .models-shell .cat-provider > .status,
+  .models-shell .cat-provider > .quick:not(:last-child) {
+    display: none;
+  }
+
+  /* Providers split-pane → single column. Rail above the panel, both
+     full-width. The rail gets a horizontal scroll bar instead of a tall
+     vertical one so it doesn't dominate the viewport. */
+  .models-shell .providers-grid {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+  .models-shell .provider-list {
+    position: static;
+    max-height: none;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: visible;
+    -webkit-overflow-scrolling: touch;
+  }
+  .models-shell .provider-list > div:first-child { display: none; }
+  .models-shell .prov-row { flex: 0 0 auto; min-width: 200px; }
+  .models-shell .provider-panel .head {
+    grid-template-columns: 36px 1fr;
+    padding: 14px 16px;
+  }
+  .models-shell .provider-panel .head > div:last-child {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+  .models-shell .provider-panel .body { padding: 14px 16px 18px; gap: 16px; }
+  .models-shell .field-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 10px 0;
+  }
+
+  /* Playground: surface above params. */
+  .models-shell .pg {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    min-height: auto;
+  }
+  .models-shell .pg .params { padding: 14px; }
+
+  /* Image canvas: 2 → 1 column on narrow screens so each result is legible. */
+  .models-shell .image-canvas {
+    grid-template-columns: 1fr;
+    padding: 14px;
+  }
+
+  /* Drawer + modals: full-width sheet. */
+  .models-shell .drawer { width: 100vw; }
+  .models-shell .drawer .top { padding: 14px 16px; }
+  .models-shell .drawer .body { padding: 16px; }
+  .models-shell .spec-grid { grid-template-columns: 1fr; }
+}

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -152,6 +152,10 @@
   position: relative;
   cursor: pointer;
   transition: border-color .12s ease;
+  /* Allow the inner `.value` text-overflow:ellipsis to actually clip —
+     flex items default to min-width:auto which lets the long mono
+     `provider/model` ids push the grid wider than its column. */
+  min-width: 0;
 }
 .models-shell .default-card:hover { border-color: var(--m-brand-deep); }
 .models-shell .default-card .row1 { display: flex; align-items: center; gap: 8px; }
@@ -810,7 +814,15 @@
     overflow-y: visible;
     -webkit-overflow-scrolling: touch;
   }
-  .models-shell .provider-list > div:first-child { display: none; }
+  .models-shell .provider-list > div:first-child {
+    /* Keep the rail header visible on mobile so the "+" button stays
+       reachable — but make it sized as part of the horizontal strip. */
+    flex: 0 0 auto;
+    border-bottom: 0;
+    border-right: 1px solid var(--m-border-soft);
+    margin-bottom: 0;
+    padding: 6px 10px;
+  }
   .models-shell .prov-row { flex: 0 0 auto; min-width: 200px; }
   .models-shell .provider-panel .head {
     grid-template-columns: 36px 1fr;

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -1,0 +1,648 @@
+/* ============================================================
+ * Models settings — dark, dense, distri-tokened.
+ *
+ * Scoped under `.models-shell` so it doesn't bleed into the rest of
+ * the app. Loaded by `AgentSettingsView`.
+ *
+ * Adapted from the design bundle (Models Settings.html /
+ * models-styles.css). Where shadcn semantic tokens (--background,
+ * --foreground, --border) already exist on the consuming app, we
+ * fall back to them via `var()` defaults.
+ * ============================================================ */
+
+.models-shell {
+  /* Local tokens — these override only inside the shell. */
+  --m-brand: #007C91;
+  --m-brand-soft: #4FB5C3;
+  --m-brand-deep: #005B6B;
+  --m-bg: var(--background, #121418);
+  --m-bg-elev: #1A1D23;
+  --m-bg-sunk: #0C0E11;
+  --m-border: #2A2F3A;
+  --m-border-soft: #1F232B;
+  --m-text: #EEF2F6;
+  --m-text-muted: #94A3B8;
+  --m-text-faint: #64748B;
+  --m-emerald: #34D399;
+  --m-amber: #F59E0B;
+  --m-rose: #F43F5E;
+  --m-violet: #8B5CF6;
+  --m-radius-sm: 6px;
+  --m-radius-md: 8px;
+  --m-radius-lg: 12px;
+  --m-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  background: var(--m-bg);
+  color: var(--m-text);
+  font-feature-settings: "ss01","cv11";
+  min-height: 100%;
+}
+.models-shell *,
+.models-shell *::before,
+.models-shell *::after { box-sizing: border-box; }
+.models-shell button { font: inherit; color: inherit; background: none; border: 0; padding: 0; cursor: pointer; }
+
+/* ── Page chrome ───────────────────────────────────────────────────── */
+.models-shell .page { padding: 20px 28px 56px; max-width: 1480px; }
+
+.models-shell .subtabs {
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 3px;
+  border-radius: var(--m-radius-md);
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+}
+.models-shell .subtab {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 13px; font-weight: 500;
+  color: var(--m-text-muted);
+}
+.models-shell .subtab:hover { color: var(--m-text); }
+.models-shell .subtab.active {
+  background: var(--m-bg); color: var(--m-text);
+  box-shadow: 0 1px 0 rgba(255,255,255,.04) inset, 0 1px 2px rgba(0,0,0,.3);
+}
+
+/* ── Default-model strip ──────────────────────────────────────────── */
+.models-shell .defaults {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.models-shell .default-card {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 12px 14px;
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-md);
+  position: relative;
+  cursor: pointer;
+  transition: border-color .12s ease;
+}
+.models-shell .default-card:hover { border-color: var(--m-brand-deep); }
+.models-shell .default-card .row1 { display: flex; align-items: center; gap: 8px; }
+.models-shell .default-card .cap-label {
+  font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--m-text-faint); font-weight: 600;
+}
+.models-shell .default-card .value {
+  font-family: var(--m-font-mono); font-size: 13px;
+  color: var(--m-text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.models-shell .default-card .value.empty {
+  font-family: inherit; color: var(--m-text-faint); font-style: italic;
+}
+.models-shell .default-card .change {
+  position: absolute; right: 10px; top: 10px;
+  font-size: 11px; color: var(--m-text-faint);
+  opacity: 0; transition: opacity .12s ease;
+}
+.models-shell .default-card:hover .change { opacity: 1; color: var(--m-brand-soft); }
+
+/* ── Capability chips ──────────────────────────────────────────────── */
+.models-shell .toolbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 0; flex-wrap: wrap;
+}
+.models-shell .cap-chips { display: flex; gap: 4px; align-items: center; }
+.models-shell .cap-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  border-radius: 7px;
+  font-size: 12.5px; font-weight: 500;
+  color: var(--m-text-muted);
+  border: 1px solid transparent;
+}
+.models-shell .cap-chip:hover { color: var(--m-text); background: rgba(255,255,255,.03); }
+.models-shell .cap-chip.active {
+  background: var(--m-bg-elev);
+  border-color: var(--m-border);
+  color: var(--m-text);
+}
+.models-shell .cap-chip .count {
+  font-family: var(--m-font-mono); font-size: 10.5px;
+  color: var(--m-text-faint);
+  padding: 1px 6px; border-radius: 9999px;
+  background: rgba(255,255,255,.04);
+}
+.models-shell .cap-chip.active .count {
+  background: rgba(34,174,195,.14); color: var(--m-brand-soft);
+}
+
+/* ── Search input ──────────────────────────────────────────────────── */
+.models-shell .search {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 12px;
+  height: 34px;
+  border-radius: var(--m-radius-md);
+  background: rgba(255,255,255,.03);
+  border: 1px solid var(--m-border);
+  min-width: 280px;
+}
+.models-shell .search input {
+  background: transparent; border: 0; outline: 0;
+  font-size: 13px; color: var(--m-text); flex: 1;
+}
+.models-shell .search input::placeholder { color: var(--m-text-faint); }
+.models-shell .search .kbd {
+  font-family: var(--m-font-mono); font-size: 11px;
+  color: var(--m-text-faint);
+  padding: 1px 6px; border-radius: 4px;
+  border: 1px solid var(--m-border);
+  background: var(--m-bg);
+}
+
+/* ── Catalog table ─────────────────────────────────────────────────── */
+.models-shell .cat-card {
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-lg);
+  overflow: hidden;
+}
+.models-shell .cat-head,
+.models-shell .cat-row,
+.models-shell .cat-provider {
+  display: grid;
+  align-items: center;
+  font-size: 13px;
+}
+.models-shell .cat-cols-completion {
+  grid-template-columns:
+    minmax(280px, 2.2fr) auto 100px 150px 100px 74px 96px;
+  column-gap: 18px;
+  padding: 0 18px;
+}
+.models-shell .cat-cols-voice {
+  grid-template-columns:
+    minmax(280px, 2.2fr) auto 140px 150px 74px 96px;
+  column-gap: 18px;
+  padding: 0 18px;
+}
+.models-shell .cat-cols-image {
+  grid-template-columns:
+    minmax(280px, 2.2fr) auto 150px 150px 74px 96px;
+  column-gap: 18px;
+  padding: 0 18px;
+}
+
+.models-shell .cat-head {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--m-text-faint);
+  padding-top: 10px; padding-bottom: 10px;
+  border-bottom: 1px solid var(--m-border);
+  background: var(--m-bg-sunk);
+  font-weight: 600;
+}
+.models-shell .cat-head .sortable {
+  display: inline-flex; align-items: center; gap: 4px;
+  cursor: pointer; color: var(--m-text-faint);
+}
+.models-shell .cat-head .sortable:hover { color: var(--m-text-muted); }
+.models-shell .cat-head .sortable.active { color: var(--m-text); }
+.models-shell .cat-head .num { text-align: right; justify-content: flex-end; }
+
+.models-shell .cat-provider {
+  grid-template-columns: 28px 1fr auto auto auto;
+  align-items: center;
+  padding: 9px 18px;
+  background: rgba(255,255,255,.015);
+  border-top: 1px solid var(--m-border-soft);
+  cursor: pointer;
+  user-select: none;
+}
+.models-shell .cat-provider:hover { background: rgba(255,255,255,.035); }
+.models-shell .cat-provider .chev { color: var(--m-text-faint); transition: transform .15s ease; }
+.models-shell .cat-provider.open .chev { transform: rotate(90deg); }
+.models-shell .cat-provider .name {
+  font-size: 11.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--m-text-muted); font-weight: 600;
+  display: flex; align-items: center; gap: 10px;
+}
+.models-shell .cat-provider .count {
+  font-size: 11.5px; color: var(--m-text-faint);
+  font-weight: 400; text-transform: none; letter-spacing: 0;
+}
+.models-shell .cat-provider .status {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+}
+.models-shell .cat-provider .status.ok { color: #6EE7B7; }
+.models-shell .cat-provider .status.bad { color: var(--m-text-faint); }
+.models-shell .cat-provider .quick {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px; border-radius: var(--m-radius-sm);
+  font-size: 11.5px; color: var(--m-text-muted);
+  border: 1px solid var(--m-border);
+  background: var(--m-bg);
+}
+.models-shell .cat-provider .quick:hover { color: var(--m-text); }
+
+.models-shell .cat-row {
+  padding-top: 11px; padding-bottom: 11px;
+  border-top: 1px solid var(--m-border-soft);
+  transition: background .12s ease;
+}
+.models-shell .cat-row.disabled { opacity: 0.45; }
+.models-shell .cat-row:hover { background: rgba(34,174,195,.04); cursor: pointer; }
+.models-shell .cat-row .model {
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 10px; align-items: center; min-width: 0;
+}
+.models-shell .cat-row .mono-pill {
+  width: 28px; height: 28px; border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--m-font-mono); font-size: 10.5px; font-weight: 600;
+  color: var(--m-text);
+  background: rgba(255,255,255,.06);
+  border: 1px solid var(--m-border);
+}
+.models-shell .cat-row .name {
+  font-size: 13.5px; color: var(--m-text); font-weight: 500;
+  line-height: 1.25;
+  display: flex; align-items: center; gap: 8px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.models-shell .cat-row .id {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--m-font-mono); font-size: 11px;
+  color: var(--m-text-faint);
+  margin-top: 1px;
+}
+.models-shell .cat-row .id .copy { color: var(--m-text-faint); opacity: 0; }
+.models-shell .cat-row:hover .id .copy { opacity: 1; }
+.models-shell .cat-row .id .copy:hover { color: var(--m-text); }
+
+.models-shell .num {
+  font-family: var(--m-font-mono); font-size: 12.5px;
+  color: var(--m-text-muted); text-align: right;
+}
+.models-shell .num strong { color: var(--m-text); font-weight: 500; }
+.models-shell .num .em { color: var(--m-text-faint); }
+
+.models-shell .starbtn { color: var(--m-text-faint); opacity: 0; padding: 4px; }
+.models-shell .cat-row:hover .starbtn { opacity: 1; }
+.models-shell .starbtn:hover { color: var(--m-brand-soft); }
+.models-shell .starbtn.on { color: var(--m-brand-soft); opacity: 1; }
+
+.models-shell .row-actions {
+  display: flex; align-items: center; gap: 4px; justify-content: flex-end;
+}
+.models-shell .row-actions button {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 6px;
+  color: var(--m-text-faint); opacity: 0;
+}
+.models-shell .cat-row:hover .row-actions button { opacity: 1; }
+.models-shell .row-actions button:hover {
+  background: rgba(255,255,255,.05); color: var(--m-text);
+}
+.models-shell .row-actions .play:hover {
+  color: var(--m-brand-soft); background: rgba(34,174,195,.12);
+}
+
+/* ── Capability pills + tags ──────────────────────────────────────── */
+.models-shell .cap-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 20px; padding: 0 8px;
+  border-radius: 999px;
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.models-shell .cap-pill.completion { background: rgba(34,174,195,.12); color: #88D7E3; border-color: rgba(34,174,195,.30); }
+.models-shell .cap-pill.tts        { background: rgba(16,185,129,.12); color: #6EE7B7; border-color: rgba(16,185,129,.30); }
+.models-shell .cap-pill.stt        { background: rgba(139,92,246,.14); color: #C4B5FD; border-color: rgba(139,92,246,.30); }
+.models-shell .cap-pill.image      { background: rgba(245,158,11,.12); color: #FCD34D; border-color: rgba(245,158,11,.30); }
+.models-shell .cap-pill .dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+.models-shell .tag {
+  display: inline-flex; align-items: center;
+  height: 18px; padding: 0 7px;
+  border-radius: 4px;
+  font-size: 10.5px; font-weight: 500;
+  background: rgba(255,255,255,.05);
+  color: var(--m-text-muted);
+  border: 1px solid var(--m-border-soft);
+}
+.models-shell .tag.flag { background: rgba(34,174,195,.10); color: var(--m-brand-soft); border-color: rgba(34,174,195,.22); }
+.models-shell .tag.legacy { color: var(--m-text-faint); }
+.models-shell .tag.deprecated { background: rgba(244,63,94,.10); color: #FDA4AF; border-color: rgba(244,63,94,.22); }
+
+.models-shell .mono {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 5px;
+  font-family: var(--m-font-mono); font-size: 10px; font-weight: 700;
+  color: var(--m-text);
+  background: rgba(255,255,255,.05);
+  border: 1px solid var(--m-border);
+  letter-spacing: 0.02em;
+}
+.models-shell .mono.lg { width: 36px; height: 36px; border-radius: 8px; font-size: 13px; }
+
+/* ── Providers split-pane ─────────────────────────────────────────── */
+.models-shell .providers-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 20px;
+  align-items: flex-start;
+}
+.models-shell .provider-list {
+  display: flex; flex-direction: column; gap: 4px;
+  border: 1px solid var(--m-border);
+  background: var(--m-bg-elev);
+  border-radius: var(--m-radius-lg);
+  padding: 8px;
+  position: sticky; top: 16px;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+.models-shell .prov-row {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 10px; align-items: center;
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.models-shell .prov-row:hover { background: rgba(255,255,255,.03); }
+.models-shell .prov-row.active { background: rgba(34,174,195,.10); }
+.models-shell .prov-row .label { font-size: 13.5px; font-weight: 500; color: var(--m-text); }
+.models-shell .prov-row .sub {
+  font-size: 11.5px; color: var(--m-text-faint); margin-top: 1px;
+  display: flex; align-items: center; gap: 6px;
+}
+.models-shell .prov-row .status-dot {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--m-text-faint);
+}
+.models-shell .prov-row .status-dot.ok {
+  background: #34D399; box-shadow: 0 0 0 3px rgba(16,185,129,.18);
+}
+
+.models-shell .provider-panel {
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-lg);
+  overflow: hidden;
+}
+.models-shell .provider-panel .head {
+  display: grid;
+  grid-template-columns: 44px 1fr auto;
+  gap: 14px; align-items: center;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--m-border-soft);
+}
+.models-shell .provider-panel .head h2 {
+  margin: 0; font-size: 18px; font-weight: 600;
+}
+.models-shell .provider-panel .head .sub {
+  color: var(--m-text-muted); font-size: 13px; margin-top: 2px;
+}
+.models-shell .provider-panel .body {
+  padding: 18px 22px 22px; display: flex; flex-direction: column; gap: 22px;
+}
+.models-shell .section-title {
+  font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--m-text-faint); font-weight: 600; margin: 0 0 10px;
+}
+.models-shell .field-row {
+  display: grid; grid-template-columns: 200px 1fr; gap: 18px; align-items: start;
+  padding: 14px 0; border-top: 1px solid var(--m-border-soft);
+}
+.models-shell .field-row:first-of-type { border-top: 0; padding-top: 0; }
+.models-shell .field-row .lbl { font-size: 13px; font-weight: 500; color: var(--m-text); }
+.models-shell .field-row .desc { color: var(--m-text-faint); font-size: 12px; margin-top: 3px; }
+
+.models-shell .input {
+  display: flex; align-items: center; gap: 8px;
+  height: 34px; padding: 0 12px;
+  border: 1px solid var(--m-border);
+  background: rgba(255,255,255,.02);
+  border-radius: var(--m-radius-md);
+  font-size: 13px;
+  width: 100%;
+}
+.models-shell .input:focus-within {
+  border-color: var(--m-brand-soft);
+  box-shadow: 0 0 0 3px rgba(34,174,195,.16);
+}
+.models-shell .input input {
+  background: transparent; border: 0; outline: 0; flex: 1;
+  font-family: var(--m-font-mono); font-size: 12.5px;
+  color: var(--m-text);
+}
+.models-shell .input input::placeholder {
+  color: var(--m-text-faint); font-family: inherit;
+}
+.models-shell .input .actions { display: flex; align-items: center; gap: 2px; }
+.models-shell .input .actions button {
+  color: var(--m-text-faint); padding: 4px; border-radius: 4px;
+}
+.models-shell .input .actions button:hover {
+  color: var(--m-text); background: rgba(255,255,255,.05);
+}
+.models-shell .input.saved { border-color: rgba(16,185,129,.30); }
+
+.models-shell .testbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,.025);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-md);
+}
+.models-shell .testbar .status {
+  font-size: 12.5px; color: var(--m-text-muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.models-shell .testbar .status.ok { color: #6EE7B7; }
+.models-shell .testbar .status.bad { color: #FDA4AF; }
+
+/* ── Buttons ──────────────────────────────────────────────────────── */
+.models-shell .btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  height: 32px; padding: 0 14px;
+  border-radius: var(--m-radius-md);
+  font-size: 13px; font-weight: 500;
+  border: 1px solid transparent;
+  transition: 100ms ease;
+  white-space: nowrap;
+}
+.models-shell .btn-primary {
+  background: var(--m-brand); color: white;
+  box-shadow: 0 1px 0 rgba(255,255,255,.06) inset;
+}
+.models-shell .btn-primary:hover { background: #008CA4; }
+.models-shell .btn-primary:disabled { opacity: .6; cursor: not-allowed; }
+.models-shell .btn-secondary {
+  background: var(--m-bg-elev); border-color: var(--m-border); color: var(--m-text);
+}
+.models-shell .btn-secondary:hover { background: rgba(255,255,255,.04); }
+.models-shell .btn-ghost { color: var(--m-text-muted); }
+.models-shell .btn-ghost:hover { color: var(--m-text); background: rgba(255,255,255,.04); }
+.models-shell .btn-danger { color: #FDA4AF; }
+.models-shell .btn-danger:hover { background: rgba(244,63,94,.10); color: #FB7185; }
+.models-shell .btn-sm { height: 26px; padding: 0 10px; font-size: 12px; }
+
+/* ── Drawer (model detail) ────────────────────────────────────────── */
+.models-shell .drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(2px);
+  z-index: 60;
+}
+.models-shell .drawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: 580px; max-width: 96vw;
+  background: var(--m-bg);
+  border-left: 1px solid var(--m-border);
+  z-index: 61;
+  display: flex; flex-direction: column;
+  box-shadow: -32px 0 60px rgba(0,0,0,.45);
+}
+.models-shell .drawer .top {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--m-border-soft);
+}
+.models-shell .drawer .top .title { flex: 1; }
+.models-shell .drawer .top h2 { margin: 0; font-size: 18px; font-weight: 600; }
+.models-shell .drawer .top .id {
+  font-family: var(--m-font-mono); font-size: 12px; color: var(--m-text-faint);
+  display: inline-flex; align-items: center; gap: 6px; margin-top: 2px;
+}
+.models-shell .drawer .body {
+  flex: 1; overflow-y: auto; padding: 20px 22px 24px;
+}
+
+.models-shell .spec-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-md);
+  overflow: hidden;
+  background: var(--m-bg-elev);
+}
+.models-shell .spec-cell {
+  padding: 12px 14px;
+  border-right: 1px solid var(--m-border-soft);
+  border-bottom: 1px solid var(--m-border-soft);
+}
+.models-shell .spec-cell:nth-child(2n) { border-right: 0; }
+.models-shell .spec-cell .k {
+  font-size: 10.5px; letter-spacing: 0.10em; text-transform: uppercase;
+  color: var(--m-text-faint); font-weight: 600;
+}
+.models-shell .spec-cell .v {
+  font-family: var(--m-font-mono); font-size: 12.5px;
+  color: var(--m-text); margin-top: 4px;
+}
+
+.models-shell .section { margin-top: 22px; }
+.models-shell .section h3 {
+  font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--m-text-faint); font-weight: 600; margin: 0 0 10px;
+}
+
+/* ── Playground layout ────────────────────────────────────────────── */
+.models-shell .pg {
+  display: grid; grid-template-columns: 1fr 320px; gap: 16px;
+  align-items: stretch;
+  min-height: calc(100vh - 200px);
+}
+.models-shell .pg .surface {
+  background: var(--m-bg-elev);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-radius-lg);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.models-shell .pg .params { padding: 18px; display: flex; flex-direction: column; gap: 18px; }
+.models-shell .pg .param .lbl {
+  display: flex; justify-content: space-between;
+  font-size: 12px; color: var(--m-text-muted); margin-bottom: 6px;
+}
+.models-shell .pg .param .lbl .v {
+  font-family: var(--m-font-mono); color: var(--m-text);
+}
+.models-shell .pg .slider {
+  appearance: none; width: 100%; height: 4px;
+  background: rgba(255,255,255,.06); border-radius: 999px;
+}
+.models-shell .pg .slider::-webkit-slider-thumb {
+  appearance: none; width: 14px; height: 14px; border-radius: 50%;
+  background: var(--m-brand-soft); cursor: pointer;
+}
+.models-shell .pg .select {
+  width: 100%;
+  background: rgba(255,255,255,.02);
+  border: 1px solid var(--m-border);
+  color: var(--m-text);
+  border-radius: var(--m-radius-md);
+  padding: 7px 10px;
+  font-size: 13px;
+}
+
+/* TTS */
+.models-shell .tts-wave {
+  height: 60px;
+  background: linear-gradient(180deg, rgba(34,174,195,.08), transparent);
+  border-radius: var(--m-radius-md);
+  position: relative; overflow: hidden;
+}
+.models-shell .tts-wave svg { width: 100%; height: 100%; }
+.models-shell .voice-card {
+  border: 1px solid var(--m-border); border-radius: var(--m-radius-md);
+  padding: 12px 14px;
+  display: grid; grid-template-columns: 1fr auto; gap: 10px; align-items: center;
+  cursor: pointer;
+}
+.models-shell .voice-card:hover { background: rgba(255,255,255,.025); }
+.models-shell .voice-card.active {
+  border-color: var(--m-brand-soft); background: rgba(34,174,195,.06);
+}
+.models-shell .voice-card .name { font-size: 13px; font-weight: 500; }
+.models-shell .voice-card .desc {
+  font-size: 11.5px; color: var(--m-text-faint); margin-top: 2px;
+}
+
+/* Image */
+.models-shell .image-canvas {
+  flex: 1;
+  background:
+    linear-gradient(135deg, transparent 24%, rgba(255,255,255,.014) 25%, rgba(255,255,255,.014) 26%, transparent 27%) 0 0 / 24px 24px,
+    var(--m-bg-sunk);
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+  padding: 18px;
+}
+.models-shell .image-tile {
+  border: 1px solid var(--m-border); border-radius: var(--m-radius-md);
+  background: linear-gradient(135deg, #1d242c, #0e1216);
+  aspect-ratio: 1;
+  position: relative; overflow: hidden;
+}
+.models-shell .image-tile img { width: 100%; height: 100%; object-fit: cover; }
+.models-shell .image-tile .meta {
+  position: absolute; left: 10px; bottom: 10px;
+  font-family: var(--m-font-mono); font-size: 10.5px;
+  color: var(--m-text-muted);
+  background: rgba(0,0,0,.5);
+  padding: 3px 7px; border-radius: 4px;
+}
+
+@keyframes m-shimmer { from { background-position: -200px 0; } to { background-position: 600px 0; } }
+.models-shell .shimmer {
+  background-color: rgba(255,255,255,.03);
+  background-image: linear-gradient(90deg, transparent, rgba(255,255,255,.05), transparent);
+  background-size: 200px 100%;
+  background-repeat: no-repeat;
+  animation: m-shimmer 1.8s linear infinite;
+}
+
+.models-shell .mono-text { font-family: var(--m-font-mono); }
+.models-shell .muted { color: var(--m-text-muted); }
+.models-shell .faint { color: var(--m-text-faint); }

--- a/packages/home/src/components/models/models.css
+++ b/packages/home/src/components/models/models.css
@@ -11,6 +11,12 @@
  * ============================================================ */
 
 .models-shell {
+  /* Stop any inner grid blowout from forcing the whole page into a
+     horizontal scroll. min-width:0 lets descendants shrink below their
+     intrinsic content width when CSS Grid asks them to. */
+  max-width: 100vw;
+  overflow-x: hidden;
+  min-width: 0;
   /* Local tokens — these override only inside the shell. */
   --m-brand: #007C91;
   --m-brand-soft: #4FB5C3;
@@ -139,7 +145,9 @@
 /* ── Default-model strip ──────────────────────────────────────────── */
 .models-shell .defaults {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  /* auto-fill + minmax: 4 cards on wide screens, 2 on tablets, 1 on
+     narrow phones — no media-query gymnastics needed. */
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 10px;
   margin-bottom: 20px;
 }
@@ -742,21 +750,24 @@
   .models-shell .toolbar { flex-wrap: wrap; gap: 8px; }
   .models-shell .search { min-width: 0; flex: 1 1 100%; }
 
-  /* Capability switcher / cap-chips can scroll horizontally rather than wrap. */
-  .models-shell .cap-chips,
+  /* Capability chips wrap to a second row on mobile (was horizontal
+     scroll which hid the Image chip off the right edge). The
+     playground cap-switcher only has two entries — let it scroll if
+     it ever needs to. */
+  .models-shell .cap-chips { flex-wrap: wrap; gap: 6px 4px; }
+  .models-shell .cap-chip { white-space: nowrap; flex-shrink: 0; }
   .models-shell .cap-switcher {
     overflow-x: auto;
     flex-wrap: nowrap;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
-  .models-shell .cap-chips::-webkit-scrollbar,
   .models-shell .cap-switcher::-webkit-scrollbar { display: none; }
-  .models-shell .cap-chip { white-space: nowrap; flex-shrink: 0; }
 
-  /* Default-model strip: 4 → 2 columns. */
+  /* Default-model strip — narrow tiles fit two per row on phones; very
+     narrow viewports fall to one column via `auto-fill`. */
   .models-shell .defaults {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     gap: 8px;
     margin-bottom: 14px;
   }

--- a/packages/home/src/components/models/primitives.tsx
+++ b/packages/home/src/components/models/primitives.tsx
@@ -1,0 +1,85 @@
+/**
+ * Small visual primitives reused across the redesigned models pages:
+ * capability pills, provider monogram chips, and the pricing-cell
+ * formatter that handles all four `ModelPricing` variants.
+ */
+
+import type { ModelCapability, ModelPricing } from '../../DistriHomeClient';
+import { CAPABILITY_META, providerMonogram } from './data';
+
+export function CapPill({ type, withDot = false }: { type: ModelCapability; withDot?: boolean }) {
+  const meta = CAPABILITY_META[type];
+  if (!meta) return null;
+  return (
+    <span className={`cap-pill ${type}`}>
+      {withDot && <span className="dot" />}
+      {meta.short}
+    </span>
+  );
+}
+
+export function MonoChip({ providerId, large = false }: { providerId: string; large?: boolean }) {
+  return (
+    <span className={large ? 'mono lg' : 'mono'} title={providerId}>
+      {providerMonogram(providerId)}
+    </span>
+  );
+}
+
+/** Inline pricing cell. `kind="cached"` renders the cached-input column
+ *  for completion pricing (and a dash otherwise). */
+export function PricingCell({
+  pricing,
+  kind,
+}: {
+  pricing?: ModelPricing;
+  kind?: 'cached';
+}) {
+  if (!pricing) return <span className="num em">—</span>;
+  if (pricing.type === 'completion') {
+    if (kind === 'cached') {
+      return pricing.cached_input != null ? (
+        <span className="num">
+          <strong>${pricing.cached_input.toFixed(2)}</strong>
+        </span>
+      ) : (
+        <span className="num em">—</span>
+      );
+    }
+    return (
+      <span className="num">
+        <strong>${pricing.input.toFixed(2)}</strong>
+        <span className="em" style={{ margin: '0 6px' }}>
+          /
+        </span>
+        <strong>${pricing.output.toFixed(2)}</strong>
+      </span>
+    );
+  }
+  if (pricing.type === 'tts') {
+    return (
+      <span className="num">
+        <strong>${pricing.per_1m_chars.toFixed(2)}</strong>{' '}
+        <span className="em">/ 1M chars</span>
+      </span>
+    );
+  }
+  if (pricing.type === 'stt') {
+    return (
+      <span className="num">
+        <strong>${pricing.per_minute.toFixed(3)}</strong> <span className="em">/ min</span>
+      </span>
+    );
+  }
+  if (pricing.type === 'image') {
+    return (
+      <span className="num">
+        <strong>${pricing.per_image.toFixed(3)}</strong>
+        <span className="em" style={{ marginLeft: 4 }}>
+          / image
+        </span>
+      </span>
+    );
+  }
+  return <span className="num em">—</span>;
+}

--- a/packages/home/src/index.ts
+++ b/packages/home/src/index.ts
@@ -28,8 +28,13 @@ export { AgentDetails } from './components/AgentDetails';
 export { ThreadsView } from './components/ThreadsView';
 export { SettingsView } from './components/SettingsView';
 export { SecretsView } from './components/SecretsView';
-export { AgentSettingsView } from './components/AgentSettingsView';
-export type { AgentSettingsViewProps } from './components/AgentSettingsView';
+export { ModelsView } from './components/models/ModelsView';
+export type {
+  ModelsViewMode,
+  ModelsViewProps,
+  ModelsNavigateTarget,
+  PlaygroundCapability,
+} from './components/models/ModelsView';
 export { VoicePreviewDialog } from './components/VoicePreviewDialog';
 export { PromptTemplatesView } from './components/PromptTemplatesView';
 export { SessionsView } from './components/SessionsView';

--- a/packages/home/src/pages/SettingsLayoutPage.tsx
+++ b/packages/home/src/pages/SettingsLayoutPage.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { BarChart3, KeyRound, Layers, LockIcon, Settings as SettingsIcon } from 'lucide-react';
 import { useDistriHome } from '../provider/context';
 import { ApiKeysManager } from '../blocks/ApiKeysManager';
-import { AgentSettingsView } from '../components/AgentSettingsView';
+import { ModelsView } from '../components/models/ModelsView';
 import { UsageWidget } from '../blocks/UsageWidget';
 import SecretsPage from './SecretsPage';
 
@@ -28,14 +28,18 @@ function makeSections(navigate: (to: string) => void, prefix: string): SectionDe
       href: '/settings/models',
       icon: Layers,
       render: () => (
-        <AgentSettingsView
-          activeTab={
-            // The /settings/models/providers sub-route activates the providers tab
-            window.location.pathname.endsWith('/providers') ? 'providers' : 'models'
-          }
-          onTabChange={(t) =>
-            navigate(t === 'providers' ? `${prefix}/settings/models/providers` : `${prefix}/settings/models`)
-          }
+        <ModelsView
+          view={window.location.pathname.endsWith('/providers') ? 'providers' : 'catalog'}
+          navigate={(t) => {
+            if (t.view === 'catalog') navigate(`${prefix}/settings/models`);
+            else if (t.view === 'providers') navigate(`${prefix}/settings/models/providers`);
+            else {
+              const p = new URLSearchParams({ mode: t.mode });
+              if (t.providerId) p.set('provider', t.providerId);
+              if (t.modelId) p.set('model', t.modelId);
+              navigate(`${prefix}/models/playground?${p.toString()}`);
+            }
+          }}
         />
       ),
     },


### PR DESCRIPTION
## Summary

Standalone `ModelsView` replacing `AgentSettingsView`, with a full redesign of the catalog + providers + playgrounds and a mobile pass.

### Page architecture
- New `ModelsView` (top-level, URL-driven). `AgentSettingsView` is deleted — `@distri/home` exports `ModelsView` and its prop types. Three sub-views routed via `view` + `playgroundMode` props: catalog (`/models`), providers (`/models/providers`), playgrounds (`/models/playground?mode=tts|image`).
- Dark, dense palette scoped under `.models-shell` (own design tokens, Inter + JetBrains Mono). Mobile breakpoint at 768 px collapses the catalog table, providers split-pane, and playground 2-col into stacked card layouts.

### Catalog
- Default-model strip (4 cards: Completion / TTS / STT / Image), capability chips with counts, search, grouped-by-provider table with configured-first sort, sortable columns.
- "Set as default" toggle lives in the **Default column itself** (`CheckCircle2` / `Circle`); no more dead favorites/star.
- Per-row actions: Play (open playground), Details (drawer).

### Providers
- Split-pane: rail (configured-first) + edit panel with credentials, inline save, mask reveal, test connection.
- "+" Custom provider modal (display name, base URL, API key, optional project id) creates a `custom_*` OpenAI-compatible provider.
- "+ Add model" modal per provider — model id + capability, appended to `custom_models` via `upsertProvider`.
- **Default-provider / default-model indicators** derived from workspace defaults: rail badge, panel header chip ("Default · Completion · TTS"), and per-row "Default" chip in the Models list.

### Playgrounds
- Voice (TTS) — wired to `generateSpeech`, audio blob + play/pause + download, voice card grid.
- Image — wired to `generateImage`, n / size / quality controls, centred flex-wrap canvas so n=1 lands centred, n=2 side-by-side, n=4 wraps to 2×2.

### Client types
- `ImageGenerateRequest` carries typed string-union enums matching the gateway (`ImageSize`, `ImageQuality`, `ImageResponseFormat`, `ImageOutputFormat`, `ImageModeration`, `ImageBackground`, `ImageStyle`).
- Drops `response_format` from the playground's request (gpt-image-* rejects it; gateway decides per-model).

## Test plan
- [ ] `pnpm type-check` in `packages/home` clean.
- [ ] Catalog: filter by capability, search, sort, toggle default, open playground from a row.
- [ ] Providers: save credentials, test connection, add custom provider (`custom_xyz`), add custom model, see "Default" badges light up on the matching provider.
- [ ] Voice playground: generate, play, download mp3/wav.
- [ ] Image playground: n=1 centred, n=2 side-by-side, n=4 grid.
- [ ] Mobile (<768 px): catalog table collapses to cards, providers stack, playgrounds stack.
- [ ] Drawer + modals fully opaque (no shadcn-token transparency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)