### PR TITLE
SDK: tags + trace context passthrough; Threads view tag filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/workspace",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "packageManager": "pnpm@10.11.1",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Core API client for Distri Framework",
   "exports": {
     ".": {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -8,6 +8,7 @@ import {
   AgentConfigWithTools,
   DynamicMetadata,
   ExecutorContextMetadata,
+  TraceContext,
 } from './types';
 import { Message, MessageSendParams } from '@a2a-js/sdk';
 import { decodeA2AStreamEvent } from './encoder';
@@ -31,6 +32,10 @@ export interface InvokeConfig {
    *  Use to control which parts are saved to the database.
    *  Parts with `save: false` will be filtered out before saving. */
   parts?: DynamicMetadata['parts'];
+  /** Arbitrary search tags forwarded as `metadata.tags`. */
+  tags?: Record<string, string>;
+  /** Inbound distributed trace context forwarded as `metadata.trace_context`. */
+  trace_context?: TraceContext;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -51,6 +51,16 @@ export interface PromptSection {
 }
 
 /**
+ * Inbound distributed trace context propagated to the backend.
+ * Matches Rust's trace-context shape (W3C-style ids).
+ * `trace_id` is 32 lowercase hex chars, `parent_span_id` is 16 lowercase hex chars.
+ */
+export interface TraceContext {
+  trace_id: string;
+  parent_span_id: string;
+}
+
+/**
  * Metadata sent by clients alongside A2A messages.
  * This is the canonical schema — matches Rust's `ExecutorContextMetadata` in distri-types.
  * All clients (CLI, browser SDK, etc.) serialize this shape.
@@ -78,6 +88,10 @@ export interface ExecutorContextMetadata {
   dry_run?: boolean;
   /** Runtime environment. Determines which system agent variants to use. */
   runtime_mode?: RuntimeMode;
+  /** Arbitrary search tags attached to the resulting spans/traces. */
+  tags?: Record<string, string>;
+  /** Inbound distributed trace context to continue an existing trace. */
+  trace_context?: TraceContext;
 }
 
 /**

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/fs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "IndexedDB-backed filesystem tools and React workspace components for Distri agents",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/home/src/DistriHomeClient.ts
+++ b/packages/home/src/DistriHomeClient.ts
@@ -84,6 +84,8 @@ export interface DetailedThreadListParams {
   search?: string;
   from_date?: string;
   to_date?: string;
+  /** Filter to threads tagged with any of these tags. */
+  tags?: string[];
   limit?: number;
   offset?: number;
 }
@@ -258,6 +260,7 @@ export class DistriHomeClient {
     if (params.search) searchParams.set('search', params.search);
     if (params.from_date) searchParams.set('from_date', params.from_date);
     if (params.to_date) searchParams.set('to_date', params.to_date);
+    if (params.tags?.length) searchParams.set('tags', params.tags.join(','));
     if (params.limit !== undefined) searchParams.set('limit', params.limit.toString());
     if (params.offset !== undefined) searchParams.set('offset', params.offset.toString());
 
@@ -279,6 +282,7 @@ export class DistriHomeClient {
       search: params.search,
       from_date: params.from_date,
       to_date: params.to_date,
+      tags: params.tags,
       limit: params.limit,
       offset: params.offset,
     });

--- a/packages/home/src/blocks/TraceTimeline.tsx
+++ b/packages/home/src/blocks/TraceTimeline.tsx
@@ -43,6 +43,10 @@ export interface TraceSummary {
   totalCost: number;
   stepCount: number;
   models: string[];
+  agentId?: string;
+  agentName?: string;
+  agentVersion?: string;
+  tags?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/home/src/components/ThreadsView.tsx
+++ b/packages/home/src/components/ThreadsView.tsx
@@ -345,6 +345,7 @@ export function ThreadsView({
   const [dialogBotId, setDialogBotId] = useState(initialBotId || '');
   const [dialogFromDate, setDialogFromDate] = useState('');
   const [dialogToDate, setDialogToDate] = useState('');
+  const [dialogTags, setDialogTags] = useState('');
 
   const {
     threads: rawThreads,
@@ -447,6 +448,14 @@ export function ThreadsView({
     [params, setParams]
   );
 
+  const handleTagClick = useCallback(
+    (tag: string) => {
+      setParams({ ...params, tags: [tag], offset: 0 });
+      setDialogTags(tag);
+    },
+    [params, setParams]
+  );
+
   const handleUserClick = useCallback(
     (userId: string) => {
       navigate(`/users/${userId}`);
@@ -470,6 +479,7 @@ export function ThreadsView({
     setDialogBotId(params.bot_id || '');
     setDialogFromDate(params.from_date ? params.from_date.split('T')[0] : '');
     setDialogToDate(params.to_date ? params.to_date.split('T')[0] : '');
+    setDialogTags(params.tags?.join(', ') || '');
     setShowFilterDialog(true);
   }, [params]);
 
@@ -484,10 +494,17 @@ export function ThreadsView({
       bot_id: dialogBotId || undefined,
       from_date: dialogFromDate ? new Date(dialogFromDate).toISOString() : undefined,
       to_date: dialogToDate ? new Date(dialogToDate + 'T23:59:59').toISOString() : undefined,
+      tags: (() => {
+        const parsed = dialogTags
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean);
+        return parsed.length ? parsed : undefined;
+      })(),
       offset: 0,
     });
     setShowFilterDialog(false);
-  }, [params, dialogAgentId, dialogExternalId, dialogUserId, dialogChannelId, dialogBotId, dialogFromDate, dialogToDate, setParams]);
+  }, [params, dialogAgentId, dialogExternalId, dialogUserId, dialogChannelId, dialogBotId, dialogFromDate, dialogToDate, dialogTags, setParams]);
 
   const clearAllFilters = useCallback(() => {
     setDialogAgentId('');
@@ -497,6 +514,7 @@ export function ThreadsView({
     setDialogBotId('');
     setDialogFromDate('');
     setDialogToDate('');
+    setDialogTags('');
     setQuickTimeFilter(null);
     setSearchInput('');
     setParams({ limit: params.limit, offset: 0 });
@@ -546,6 +564,7 @@ export function ThreadsView({
     params.from_date,
     params.to_date,
     params.search,
+    params.tags?.length ? 'tags' : undefined,
   ].filter(Boolean).length;
 
   const showWarning = Boolean(error);
@@ -652,7 +671,7 @@ export function ThreadsView({
                 {filter === '7d' && 'Last 7 days'}
               </button>
             ))}
-            {(params.agent_id || params.external_id || params.user_id || params.channel_id || params.search) && (
+            {(params.agent_id || params.external_id || params.user_id || params.channel_id || params.search || params.tags?.length) && (
               <button
                 type="button"
                 onClick={clearAllFilters}
@@ -793,13 +812,19 @@ export function ThreadsView({
                       {thread.tags && thread.tags.length > 0 && (
                         <div className="mt-2 flex flex-wrap gap-1">
                           {thread.tags.map((tag) => (
-                            <span
+                            <button
                               key={tag}
-                              className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground"
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleTagClick(tag);
+                              }}
+                              className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition hover:bg-primary/10 hover:text-primary"
+                              title={`Filter by tag: ${tag}`}
                             >
                               <Tag className="h-2.5 w-2.5" />
                               {tag}
-                            </span>
+                            </button>
                           ))}
                         </div>
                       )}
@@ -964,6 +989,23 @@ export function ThreadsView({
                   placeholder="Filter by bot ID..."
                   className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm text-foreground"
                 />
+              </div>
+
+              {/* Tags */}
+              <div>
+                <label className="mb-2 block text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Tags
+                </label>
+                <input
+                  type="text"
+                  value={dialogTags}
+                  onChange={(e) => setDialogTags(e.target.value)}
+                  placeholder="Comma-separated, e.g. team, prod"
+                  className="h-10 w-full rounded-md border border-border/70 bg-background px-3 text-sm text-foreground"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Threads matching any of these tags are shown.
+                </p>
               </div>
 
               {/* Date range */}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@distri/react",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "React hooks and components for Distri Framework",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Lets callers pass arbitrary search **tags** and an inbound distributed **trace context** when invoking an agent, and adds a tag filter to the Threads view.

### Core SDK
- New `TraceContext { trace_id, parent_span_id }`.
- `tags?: Record<string,string>` and `trace_context?: TraceContext` on `ExecutorContextMetadata` and `InvokeConfig`, merged into outgoing A2A metadata as snake_case keys (matching the Rust backend).
- `TraceSummary` gains `agentId/agentName/agentVersion/tags`.

### Home / Threads view
- Tag filter input in the filter dialog + clickable tag chips that filter; `tags` serialized through `listDetailedThreads`.

## Testing
- `@distri/core` builds; touched files type-check clean (remaining monorepo errors are pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAAfoUvTsLHi8XczBeKxxU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAAfoUvTsLHi8XczBeKxxU)_