### PR TITLE
Add system slash commands and manual context compaction

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -328,6 +328,14 @@ export class Agent {
   }
 
   /**
+   * Manually compact the conversation history for `taskId`. Thin wrapper
+   * over `DistriClient.compactTask()` — see that method for behavior.
+   */
+  async compact(taskId: string) {
+    return this.client.compactTask(taskId);
+  }
+
+  /**
    * List all available agents
    */
   static async list(client: DistriClient): Promise<Agent[]> {

--- a/packages/core/src/distri-client.ts
+++ b/packages/core/src/distri-client.ts
@@ -33,6 +33,7 @@ import {
   ModelWithProvider,
   TtsSpeechRequest,
   TtsSpeechResponse,
+  CompactTaskResult,
 } from './types';
 import { convertA2AMessageToDistri, convertDistriMessageToA2A } from './encoder';
 
@@ -1087,6 +1088,34 @@ export class DistriClient {
       this.debug(`Cancelled task ${taskId} on agent ${agentId}`);
     } catch (error) {
       throw new DistriError(`Failed to cancel task ${taskId} on agent ${agentId}`, 'CANCEL_TASK_ERROR', error);
+    }
+  }
+
+  /**
+   * Manually compact the conversation history for a task. Calls
+   * `POST /v1/tasks/{taskId}/compact`. The server runs the same compactor as
+   * the agent loop's auto-trigger, unconditionally.
+   *
+   * Returns the parsed JSON body — `{ compacted, tokens_before, tokens_after,
+   * entries_affected, usage_ratio, tier }` when compaction ran, or
+   * `{ compacted: false, reason }` when there was nothing to compact.
+   */
+  async compactTask(taskId: string): Promise<CompactTaskResult> {
+    try {
+      const response = await this.fetch(`/tasks/${encodeURIComponent(taskId)}/compact`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new DistriError(
+          `Failed to compact task ${taskId}: ${response.status} ${text}`,
+          'COMPACT_TASK_ERROR'
+        );
+      }
+      return (await response.json()) as CompactTaskResult;
+    } catch (error) {
+      if (error instanceof DistriError) throw error;
+      throw new DistriError(`Failed to compact task ${taskId}`, 'COMPACT_TASK_ERROR', error);
     }
   }
 

--- a/packages/core/src/encoder.ts
+++ b/packages/core/src/encoder.ts
@@ -247,6 +247,45 @@ export function convertA2AStatusUpdateToDistri(statusUpdate: any): DistriEvent |
       } as TodosUpdatedEvent);
     }
 
+    case 'context_budget_update': {
+      return out({
+        type: 'context_budget_update',
+        data: {
+          budget: metadata.budget,
+          is_warning: !!metadata.is_warning,
+          is_critical: !!metadata.is_critical,
+        },
+      } as any);
+    }
+
+    case 'context_compaction': {
+      return out({
+        type: 'context_compaction',
+        data: {
+          tier: metadata.tier,
+          tokens_before: metadata.tokens_before ?? 0,
+          tokens_after: metadata.tokens_after ?? 0,
+          entries_affected: metadata.entries_affected ?? 0,
+          context_limit: metadata.context_limit ?? 0,
+          usage_ratio: metadata.usage_ratio ?? 0,
+          summary: metadata.summary,
+          reinjected_skills: metadata.reinjected_skills,
+          context_budget: metadata.context_budget,
+          source: metadata.source,
+          duration_ms: metadata.duration_ms,
+        },
+      } as any);
+    }
+
+    case 'compaction_requested': {
+      // Pre-compaction signal — let the store render an in-flight UI.
+      // No DistriEvent variant exists for this yet; passthrough is fine.
+      return out({
+        type: 'compaction_requested',
+        data: { source: metadata.source ?? 'auto' },
+      } as any);
+    }
+
     default: {
       // For unrecognized metadata types, create a generic run_started event
       console.warn(`Unhandled status update metadata type: ${metadata.type}`, metadata);

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -240,6 +240,40 @@ export interface LiveViewEvent {
 }
 
 /**
+ * Per-turn snapshot of the planner's context budget. Mirrors the server's
+ * `ContextBudgetUpdate` event.
+ */
+export interface ContextBudgetUpdateEvent {
+  type: 'context_budget_update';
+  data: {
+    budget: import('./types').ContextBudget;
+    is_warning: boolean;
+    is_critical: boolean;
+  };
+}
+
+/**
+ * Fired when the agent compacts conversation history. Mirrors the server's
+ * `ContextCompaction` event.
+ */
+export interface ContextCompactionStreamEvent {
+  type: 'context_compaction';
+  data: {
+    tier: 'trim' | 'summarize' | 'reset';
+    tokens_before: number;
+    tokens_after: number;
+    entries_affected: number;
+    context_limit: number;
+    usage_ratio: number;
+    summary?: string;
+    reinjected_skills?: string[];
+    context_budget?: import('./types').ContextBudget;
+    source?: 'auto' | 'manual';
+    duration_ms?: number;
+  };
+}
+
+/**
  * Routing envelope present on every decoded DistriEvent.
  *
  * Every consumer (chatStateStore reducer, useChat handlers, custom UIs) MUST
@@ -284,4 +318,6 @@ export type DistriEvent =
   | WithEnvelope<BrowserSessionStartedEvent>
   | WithEnvelope<InlineHookRequestedEvent>
   | WithEnvelope<TodosUpdatedEvent>
-  | WithEnvelope<LiveViewEvent>;
+  | WithEnvelope<LiveViewEvent>
+  | WithEnvelope<ContextBudgetUpdateEvent>
+  | WithEnvelope<ContextCompactionStreamEvent>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -348,6 +348,42 @@ export interface ContextCompactionEvent {
   usage_ratio: number;
   /** Optional summary text (for Tier 2 summarization) */
   summary?: string;
+  /** "auto" when fired by the agent loop, "manual" when via /compact. */
+  source?: 'auto' | 'manual';
+}
+
+/**
+ * Per-component context budget breakdown. Mirrors `ContextBudget` on the
+ * server. Emitted on every turn as part of `ContextBudgetUpdate`.
+ */
+export interface ContextBudget {
+  system_prompt_static_tokens: number;
+  system_prompt_dynamic_tokens: number;
+  tool_schema_tokens: number;
+  deferred_tool_tokens: number;
+  skill_listing_tokens: number;
+  conversation_tokens: number;
+  tool_result_tokens: number;
+  context_window_size: number;
+  static_prefix_cache_hit: boolean;
+  static_prefix_hash?: string;
+}
+
+/**
+ * Result body returned by `DistriClient.compactTask()` /
+ * `Agent.compact()` — mirrors `POST /v1/tasks/{task_id}/compact`.
+ */
+export interface CompactTaskResult {
+  /** True when entries were modified; false means there was nothing to compact. */
+  compacted: boolean;
+  /** Reason text when `compacted === false`. */
+  reason?: string;
+  /** Compaction tier applied (only set when `compacted === true`). */
+  tier?: CompactionTier;
+  tokens_before?: number;
+  tokens_after?: number;
+  entries_affected?: number;
+  usage_ratio?: number;
 }
 
 /**

--- a/packages/react/src/components/ChatCompactionContext.stories.tsx
+++ b/packages/react/src/components/ChatCompactionContext.stories.tsx
@@ -1,0 +1,506 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect, useState } from 'react';
+import { ContextUsagePanel, type CompactionLogItem } from './ContextUsagePanel';
+import { ContextIndicator } from './ContextIndicator';
+import type { ContextBudget, ContextHealth } from '@distri/core';
+
+/**
+ * Compaction surfaces in the context of a real chat layout:
+ *
+ *   ┌──────────────────────────────────────────┬──────────────┐
+ *   │ Coder agent · gpt-5.1                    │              │
+ *   │ ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱▱  86% context used      │   Context    │
+ *   ├──────────────────────────────────────────┤   usage      │
+ *   │ user:      Read the auth README          │   panel      │
+ *   │ assistant: ...                           │              │
+ *   │   tool:    Read('auth/README.md')        │              │
+ *   │ ...                                      │              │
+ *   ├──────────────────────────────────────────┤              │
+ *   │  > type a message...                     │              │
+ *   └──────────────────────────────────────────┴──────────────┘
+ *
+ * The thin `<ContextIndicator />` lives just under the chat header — it's
+ * the at-a-glance signal. The rich `<ContextUsagePanel />` lives in the
+ * sidebar; users open it to see the breakdown or hit "Compact now".
+ *
+ * Both flip to the compacting state from the SAME `isCompacting` flag in
+ * `chatStateStore`, so a `compaction_requested` event lights up both
+ * surfaces in lockstep — and a `context_compaction` arrival drops them
+ * back to idle at the same instant.
+ */
+const meta: Meta = {
+  title: 'Compaction/Chat layout',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+function makeBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
+  return {
+    system_prompt_static_tokens: 4_100,
+    system_prompt_dynamic_tokens: 1_200,
+    tool_schema_tokens: 5_400,
+    deferred_tool_tokens: 800,
+    skill_listing_tokens: 600,
+    conversation_tokens: 1_500,
+    tool_result_tokens: 320,
+    context_window_size: 200_000,
+    static_prefix_cache_hit: true,
+    ...overrides,
+  };
+}
+
+function totalTokens(b: ContextBudget): number {
+  return (
+    b.system_prompt_static_tokens +
+    b.system_prompt_dynamic_tokens +
+    b.tool_schema_tokens +
+    b.deferred_tool_tokens +
+    b.skill_listing_tokens +
+    b.conversation_tokens +
+    b.tool_result_tokens
+  );
+}
+
+function budgetToHealth(b: ContextBudget): ContextHealth {
+  const total = totalTokens(b);
+  return {
+    usage_ratio: total / b.context_window_size,
+    tokens_used: total,
+    tokens_limit: b.context_window_size,
+  };
+}
+
+type Phase = 'idle-heavy' | 'requested' | 'completed';
+
+/** Sample assistant/user/tool transcript that fills the message column. */
+const FAKE_MESSAGES = [
+  { role: 'user', text: 'Read the auth README and tell me how refresh tokens are rotated.' },
+  {
+    role: 'assistant',
+    text: "I'll start by reading the README, then trace the refresh flow.",
+  },
+  { role: 'tool', text: "Read('server/auth/README.md')" },
+  {
+    role: 'assistant',
+    text: 'The README points at `RefreshSession::rotate` in `session.rs`. Let me read that next.',
+  },
+  { role: 'tool', text: "Read('server/auth/session.rs', offset=120, limit=80)" },
+  {
+    role: 'assistant',
+    text:
+      'Rotation issues a new refresh token, marks the old one revoked in the same transaction, and ties them to the same `family_id`. ' +
+      'Reuse of a revoked token in a family voids the whole family — a standard rotation-with-detection pattern.',
+  },
+  { role: 'user', text: 'Walk through the postgres queries it runs and the order.' },
+  {
+    role: 'assistant',
+    text: "I'll trace through the function step by step:",
+  },
+  { role: 'tool', text: "Grep('rotate', glob='server/auth/*.rs')" },
+  { role: 'tool', text: "Read('server/auth/session.rs', offset=200, limit=120)" },
+  {
+    role: 'assistant',
+    text:
+      '1. `SELECT … WHERE token = $1 FOR UPDATE` (lock the row)\n' +
+      '2. Validate `expires_at > now()` and `revoked_at IS NULL`\n' +
+      '3. `INSERT INTO refresh_tokens (family_id, parent_id, ...)` for the new token\n' +
+      '4. `UPDATE refresh_tokens SET revoked_at = now() WHERE id = $old`\n' +
+      'All inside a single transaction so a crash mid-flight leaves the family intact.',
+  },
+];
+
+function ChatShell({
+  phase,
+  budget,
+  compactions,
+}: {
+  phase: Phase;
+  budget: ContextBudget;
+  compactions: CompactionLogItem[];
+}) {
+  const isCompacting = phase === 'requested';
+
+  return (
+    <div style={shellOuter}>
+      <div style={shellMain}>
+        {/* Chat column */}
+        <div style={chatCol}>
+          {/* Header */}
+          <div style={chatHeader}>
+            <div>
+              <div style={headerTitle}>coder · gpt-5.1</div>
+              <div style={headerSubtitle}>Thread bb84-…-9c1f</div>
+            </div>
+            <div style={headerRight}>
+              <span style={phaseBadge(phase)}>{phaseLabel(phase)}</span>
+            </div>
+          </div>
+
+          {/* Thin indicator strip — directly under the header */}
+          <div style={indicatorStrip}>
+            <ContextIndicator
+              contextHealth={budgetToHealth(budget)}
+              isCompacting={isCompacting}
+            />
+          </div>
+
+          {/* Messages */}
+          <div style={messagesScroll}>
+            {FAKE_MESSAGES.map((m, i) => (
+              <MessageRow key={i} role={m.role} text={m.text} />
+            ))}
+            {phase === 'completed' && (
+              <div style={inlineCompactionNotice}>
+                ─── compacted 124 entries · 171k → 53k tokens (69% reduction) ───
+              </div>
+            )}
+            {isCompacting && (
+              <div style={inlineCompactingNotice}>
+                <span style={spinner} aria-hidden />
+                <span>Summarizing earlier turns…</span>
+              </div>
+            )}
+          </div>
+
+          {/* Composer */}
+          <div style={composer}>
+            <div style={composerInput}>type a message…</div>
+            <button style={composerSend} disabled={isCompacting}>
+              Send
+            </button>
+          </div>
+        </div>
+
+        {/* Sidebar — Context usage panel lives here */}
+        <div style={sidebar}>
+          <div style={sidebarLabel}>Context</div>
+          <ContextUsagePanel
+            budget={budget}
+            compactions={compactions}
+            isCompacting={isCompacting}
+            onCompact={() => {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageRow({ role, text }: { role: string; text: string }) {
+  const style =
+    role === 'user'
+      ? userBubble
+      : role === 'tool'
+      ? toolBubble
+      : assistantBubble;
+  return (
+    <div style={msgRow}>
+      <div style={msgRoleLabel}>{role}</div>
+      <div style={{ ...msgBubble, ...style }}>{text}</div>
+    </div>
+  );
+}
+
+const phaseLabel = (p: Phase) =>
+  p === 'idle-heavy' ? 'idle' : p === 'requested' ? 'compacting' : 'idle (post-compact)';
+
+function phaseBadge(p: Phase): React.CSSProperties {
+  const palette =
+    p === 'requested'
+      ? { bg: '#dbeafe', fg: '#1d4ed8' }
+      : p === 'completed'
+      ? { bg: '#dcfce7', fg: '#15803d' }
+      : { bg: '#f3f4f6', fg: '#6b7280' };
+  return {
+    background: palette.bg,
+    color: palette.fg,
+    padding: '3px 8px',
+    borderRadius: 999,
+    fontSize: 10,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Stories
+// ────────────────────────────────────────────────────────────────────
+
+const heavyBudget = makeBudget({
+  conversation_tokens: 152_000,
+  tool_result_tokens: 6_800,
+});
+const lightBudget = makeBudget({
+  conversation_tokens: 38_400,
+  tool_result_tokens: 2_100,
+});
+
+export const Idle: StoryObj = {
+  name: '① Idle (78% — pre-compaction)',
+  render: () => (
+    <ChatShell phase="idle-heavy" budget={heavyBudget} compactions={[]} />
+  ),
+};
+
+export const Compacting: StoryObj = {
+  name: '② Compacting (in flight)',
+  render: () => (
+    <ChatShell phase="requested" budget={heavyBudget} compactions={[]} />
+  ),
+};
+
+export const AfterCompaction: StoryObj = {
+  name: '③ After compaction (26% + log entry)',
+  render: () => (
+    <ChatShell
+      phase="completed"
+      budget={lightBudget}
+      compactions={[
+        {
+          ts: Date.now(),
+          before: totalTokens(heavyBudget),
+          after: totalTokens(lightBudget),
+          tier: 'summarize',
+          source: 'auto',
+        },
+      ]}
+    />
+  ),
+};
+
+export const FullLifecycleLoop: StoryObj = {
+  name: 'Full lifecycle (auto-cycles)',
+  render: () => {
+    const [phase, setPhase] = useState<Phase>('idle-heavy');
+    const [log, setLog] = useState<CompactionLogItem[]>([]);
+    useEffect(() => {
+      const seq: Array<[Phase, number]> = [
+        ['idle-heavy', 2500],
+        ['requested', 2500],
+        ['completed', 3000],
+      ];
+      let idx = 0;
+      const tick = () => {
+        const [p, d] = seq[idx % seq.length];
+        setPhase(p);
+        if (p === 'completed') {
+          setLog((prev) =>
+            [
+              ...prev,
+              {
+                ts: Date.now(),
+                before: totalTokens(heavyBudget),
+                after: totalTokens(lightBudget),
+                tier: 'summarize' as const,
+                source: 'auto' as const,
+              },
+            ].slice(-3),
+          );
+        }
+        idx += 1;
+        timer = window.setTimeout(tick, d);
+      };
+      let timer = window.setTimeout(tick, seq[0][1]);
+      return () => window.clearTimeout(timer);
+    }, []);
+    const budget = phase === 'completed' ? lightBudget : heavyBudget;
+    return <ChatShell phase={phase} budget={budget} compactions={log} />;
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Layout styles — a minimal "chat shell" so the indicator + panel land
+// where they would in a real Distri chat layout. Not meant to be a
+// pixel-perfect Chat.tsx replica — just enough so the position +
+// proportions match.
+// ────────────────────────────────────────────────────────────────────
+
+const shellOuter: React.CSSProperties = {
+  height: '100vh',
+  background: '#f3f4f6',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+const shellMain: React.CSSProperties = {
+  flex: 1,
+  display: 'grid',
+  gridTemplateColumns: '1fr 360px',
+  gap: 12,
+  padding: 12,
+  minHeight: 0,
+};
+
+const chatCol: React.CSSProperties = {
+  background: '#fff',
+  borderRadius: 10,
+  border: '1px solid #e5e7eb',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 0,
+  overflow: 'hidden',
+};
+
+const chatHeader: React.CSSProperties = {
+  padding: '12px 16px',
+  borderBottom: '1px solid #e5e7eb',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+};
+
+const headerTitle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#111827',
+};
+
+const headerSubtitle: React.CSSProperties = {
+  fontSize: 11,
+  color: '#6b7280',
+  marginTop: 2,
+};
+
+const headerRight: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+};
+
+const indicatorStrip: React.CSSProperties = {
+  padding: '8px 16px',
+  borderBottom: '1px solid #f3f4f6',
+  background: '#fafafa',
+};
+
+const messagesScroll: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '12px 16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const msgRow: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+};
+
+const msgRoleLabel: React.CSSProperties = {
+  fontSize: 10,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+};
+
+const msgBubble: React.CSSProperties = {
+  borderRadius: 8,
+  padding: '8px 12px',
+  fontSize: 12,
+  lineHeight: 1.5,
+  whiteSpace: 'pre-wrap',
+};
+
+const userBubble: React.CSSProperties = {
+  background: '#eff6ff',
+  color: '#1e3a8a',
+  border: '1px solid #dbeafe',
+  alignSelf: 'flex-end',
+  maxWidth: '85%',
+};
+
+const assistantBubble: React.CSSProperties = {
+  background: '#fff',
+  color: '#111827',
+  border: '1px solid #e5e7eb',
+  maxWidth: '90%',
+};
+
+const toolBubble: React.CSSProperties = {
+  background: '#f9fafb',
+  color: '#374151',
+  border: '1px solid #e5e7eb',
+  fontFamily: 'ui-monospace, monospace',
+  fontSize: 11,
+  maxWidth: '90%',
+};
+
+const inlineCompactingNotice: React.CSSProperties = {
+  alignSelf: 'center',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  background: '#eff6ff',
+  color: '#1d4ed8',
+  padding: '6px 12px',
+  borderRadius: 999,
+  fontSize: 11,
+  fontWeight: 500,
+  border: '1px solid #bfdbfe',
+};
+
+const inlineCompactionNotice: React.CSSProperties = {
+  alignSelf: 'center',
+  background: '#f3f4f6',
+  color: '#6b7280',
+  padding: '4px 12px',
+  borderRadius: 4,
+  fontSize: 11,
+  fontFamily: 'ui-monospace, monospace',
+};
+
+const spinner: React.CSSProperties = {
+  display: 'inline-block',
+  width: 10,
+  height: 10,
+  borderRadius: '50%',
+  border: '2px solid #93c5fd',
+  borderTopColor: '#1d4ed8',
+  animation: 'distri-ctx-spin 0.8s linear infinite',
+};
+
+const composer: React.CSSProperties = {
+  borderTop: '1px solid #e5e7eb',
+  padding: 12,
+  display: 'flex',
+  gap: 8,
+};
+
+const composerInput: React.CSSProperties = {
+  flex: 1,
+  background: '#f9fafb',
+  border: '1px solid #e5e7eb',
+  borderRadius: 8,
+  padding: '8px 12px',
+  fontSize: 12,
+  color: '#9ca3af',
+};
+
+const composerSend: React.CSSProperties = {
+  background: '#1d4ed8',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 8,
+  padding: '8px 14px',
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: 'pointer',
+};
+
+const sidebar: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+};
+
+const sidebarLabel: React.CSSProperties = {
+  fontSize: 10,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  paddingLeft: 4,
+};

--- a/packages/react/src/components/CompactionLifecycle.stories.tsx
+++ b/packages/react/src/components/CompactionLifecycle.stories.tsx
@@ -1,0 +1,252 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect, useState } from 'react';
+import { ContextUsagePanel, type CompactionLogItem } from './ContextUsagePanel';
+import { ContextIndicator } from './ContextIndicator';
+import type { ContextBudget, ContextHealth } from '@distri/core';
+
+/**
+ * Interactive stories that walk through the compaction lifecycle:
+ *
+ *   idle  →  compaction_requested  →  context_compaction  →  idle
+ *
+ * The store-driven UI flips `isCompacting: true` on the request event,
+ * holds the shimmer for the round-trip, then flips back as the compaction
+ * event lands carrying the post-compact budget snapshot.
+ */
+const meta: Meta = {
+  title: 'Compaction/Lifecycle',
+  parameters: { layout: 'padded' },
+};
+export default meta;
+
+function makeBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
+  return {
+    system_prompt_static_tokens: 4_100,
+    system_prompt_dynamic_tokens: 1_200,
+    tool_schema_tokens: 5_400,
+    deferred_tool_tokens: 800,
+    skill_listing_tokens: 600,
+    conversation_tokens: 1_500,
+    tool_result_tokens: 320,
+    context_window_size: 200_000,
+    static_prefix_cache_hit: true,
+    ...overrides,
+  };
+}
+
+function totalTokens(b: ContextBudget): number {
+  return (
+    b.system_prompt_static_tokens +
+    b.system_prompt_dynamic_tokens +
+    b.tool_schema_tokens +
+    b.deferred_tool_tokens +
+    b.skill_listing_tokens +
+    b.conversation_tokens +
+    b.tool_result_tokens
+  );
+}
+
+/**
+ * Looped lifecycle: holds each phase for ~2s so the visual is easy to follow.
+ * Useful as a screenshot target — each frame stays still long enough for
+ * Playwright to capture it cleanly.
+ */
+function LifecyclePanel({ paused }: { paused?: boolean }) {
+  const heavy = makeBudget({
+    conversation_tokens: 152_000,
+    tool_result_tokens: 6_800,
+  });
+  const light = makeBudget({
+    conversation_tokens: 38_400,
+    tool_result_tokens: 2_100,
+  });
+
+  type Phase = 'idle-heavy' | 'requested' | 'completed';
+  const [phase, setPhase] = useState<Phase>('idle-heavy');
+  const [log, setLog] = useState<CompactionLogItem[]>([]);
+
+  useEffect(() => {
+    if (paused) return;
+    const sequence: Array<[Phase, number]> = [
+      ['idle-heavy', 2200],
+      ['requested', 2200],
+      ['completed', 2600],
+    ];
+    let idx = 0;
+    const next = () => {
+      const [p, delay] = sequence[idx % sequence.length];
+      setPhase(p);
+      if (p === 'completed') {
+        setLog((prev) =>
+          [
+            ...prev,
+            {
+              ts: Date.now(),
+              before: totalTokens(heavy),
+              after: totalTokens(light),
+              tier: 'summarize' as const,
+              source: 'auto' as const,
+            },
+          ].slice(-5),
+        );
+      }
+      idx += 1;
+      return delay;
+    };
+    let timer = window.setTimeout(function tick() {
+      const d = next();
+      timer = window.setTimeout(tick, d);
+    }, next());
+    return () => window.clearTimeout(timer);
+  }, [paused]);
+
+  const budget = phase === 'completed' ? light : heavy;
+  const isCompacting = phase === 'requested';
+
+  return (
+    <div style={{ maxWidth: 420, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ fontSize: 11, color: '#6b7280' }}>
+        Phase:&nbsp;
+        <code style={{ background: '#f3f4f6', padding: '1px 6px', borderRadius: 4 }}>
+          {phase}
+        </code>
+      </div>
+      <ContextUsagePanel
+        budget={budget}
+        compactions={log}
+        isCompacting={isCompacting}
+        onCompact={() => {}}
+      />
+    </div>
+  );
+}
+
+/**
+ * Side-by-side: the thin `<ContextIndicator />` (chat header) and the rich
+ * `<ContextUsagePanel />` (settings panel) flipping in sync.
+ */
+function LifecycleBoth() {
+  const heavy = makeBudget({
+    conversation_tokens: 168_000,
+    tool_result_tokens: 8_200,
+    static_prefix_cache_hit: false,
+  });
+  const light = makeBudget({ conversation_tokens: 22_400, tool_result_tokens: 1_800 });
+
+  type Phase = 'idle-heavy' | 'requested' | 'completed';
+  const [phase, setPhase] = useState<Phase>('idle-heavy');
+
+  useEffect(() => {
+    const seq: Array<[Phase, number]> = [
+      ['idle-heavy', 2000],
+      ['requested', 2200],
+      ['completed', 2400],
+    ];
+    let idx = 0;
+    const tick = () => {
+      const [p, d] = seq[idx % seq.length];
+      setPhase(p);
+      idx += 1;
+      timer = window.setTimeout(tick, d);
+    };
+    let timer = window.setTimeout(tick, seq[0][1]);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const budget = phase === 'completed' ? light : heavy;
+  const isCompacting = phase === 'requested';
+  const total = totalTokens(budget);
+  const health: ContextHealth = {
+    usage_ratio: total / budget.context_window_size,
+    tokens_used: total,
+    tokens_limit: budget.context_window_size,
+    last_compaction: phase === 'completed'
+      ? {
+          type: 'context_compaction',
+          tier: 'summarize',
+          tokens_before: totalTokens(heavy),
+          tokens_after: total,
+          entries_affected: 124,
+          context_limit: budget.context_window_size,
+          usage_ratio: total / budget.context_window_size,
+          source: 'auto',
+        }
+      : undefined,
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 460 }}>
+      <div>
+        <div style={miniLabel}>Chat header bar (thin indicator)</div>
+        <div style={{ background: '#f9fafb', padding: 10, borderRadius: 6 }}>
+          <ContextIndicator contextHealth={health} isCompacting={isCompacting} />
+        </div>
+      </div>
+      <div>
+        <div style={miniLabel}>Settings / sidebar (full panel)</div>
+        <ContextUsagePanel
+          budget={budget}
+          compactions={[]}
+          isCompacting={isCompacting}
+          onCompact={() => {}}
+        />
+      </div>
+    </div>
+  );
+}
+
+const miniLabel: React.CSSProperties = {
+  fontSize: 10,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  marginBottom: 4,
+};
+
+export const AnimatedLifecycle: StoryObj = {
+  name: 'Animated lifecycle (panel)',
+  render: () => <LifecyclePanel />,
+};
+
+export const PausedDuringCompaction: StoryObj = {
+  name: 'Paused mid-compaction (shimmer + spinner)',
+  render: () => {
+    // Render the requested phase statically so screenshots capture the
+    // shimmer + spinner in the bar without timing-dependent flake.
+    const heavy = makeBudget({
+      conversation_tokens: 152_000,
+      tool_result_tokens: 6_800,
+    });
+    return (
+      <div style={{ maxWidth: 420 }}>
+        <ContextUsagePanel budget={heavy} isCompacting onCompact={() => {}} />
+      </div>
+    );
+  },
+};
+
+export const BothSurfaces: StoryObj = {
+  name: 'Both surfaces in sync',
+  render: () => <LifecycleBoth />,
+};
+
+export const ChatHeaderCompacting: StoryObj = {
+  name: 'Chat header (thin indicator) compacting',
+  render: () => {
+    const heavy = makeBudget({
+      conversation_tokens: 152_000,
+      tool_result_tokens: 6_800,
+    });
+    const total = totalTokens(heavy);
+    const health: ContextHealth = {
+      usage_ratio: total / heavy.context_window_size,
+      tokens_used: total,
+      tokens_limit: heavy.context_window_size,
+    };
+    return (
+      <div style={{ maxWidth: 360, background: '#f9fafb', padding: 12, borderRadius: 8 }}>
+        <ContextIndicator contextHealth={health} isCompacting />
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/ContextControl.stories.tsx
+++ b/packages/react/src/components/ContextControl.stories.tsx
@@ -1,0 +1,332 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect, useState } from 'react';
+import { ContextControl, ContextUsageModal } from './ContextControl';
+import { useChatStateStore } from '../stores/chatStateStore';
+import type { ContextBudget } from '@distri/core';
+
+/**
+ * `<ContextControl />` is the recommended integration point for the
+ * compaction surface. It does NOT alter the default `<Chat>` view —
+ * instead, consumers drop it next to their composer and it lights up
+ * once the agent starts emitting `context_budget_update` events.
+ *
+ * Behaviour:
+ * - Renders nothing until utilization crosses `minUtilization` (default
+ *   25%) so short conversations stay clean.
+ * - Click → opens a modal with the full `<ContextUsagePanel />`.
+ * - During compaction → shimmer + spinner; clicking is a no-op.
+ *
+ * Stories below seed `chatStateStore` directly so they render without
+ * a live agent.
+ */
+const meta: Meta = {
+  title: 'Compaction/ContextControl',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+function makeBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
+  return {
+    system_prompt_static_tokens: 4_100,
+    system_prompt_dynamic_tokens: 1_200,
+    tool_schema_tokens: 5_400,
+    deferred_tool_tokens: 800,
+    skill_listing_tokens: 600,
+    conversation_tokens: 1_500,
+    tool_result_tokens: 320,
+    context_window_size: 200_000,
+    static_prefix_cache_hit: true,
+    ...overrides,
+  };
+}
+
+/** Seed the chat-state store with a given snapshot, then render children. */
+function StoreFixture({
+  budget,
+  isCompacting = false,
+  compactions = [],
+  children,
+}: {
+  budget?: ContextBudget;
+  isCompacting?: boolean;
+  compactions?: ReturnType<typeof useChatStateStore.getState>['compactionEvents'];
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    useChatStateStore.setState({ contextBudget: budget, isCompacting, compactionEvents: compactions });
+    return () => {
+      useChatStateStore.setState({
+        contextBudget: undefined,
+        isCompacting: false,
+        compactionEvents: [],
+      });
+    };
+  }, [budget, isCompacting, compactions]);
+  return <>{children}</>;
+}
+
+/** Minimal chat shell mock — the default `<Chat>` view, untouched. The
+ *  `<ContextControl />` slot sits next to the composer's tool row. */
+function MockChat({ control }: { control?: React.ReactNode }) {
+  return (
+    <div style={shellOuter}>
+      <div style={chatCol}>
+        <div style={chatHeader}>
+          <div>
+            <div style={headerTitle}>coder · gpt-5.1</div>
+            <div style={headerSubtitle}>Thread bb84-…-9c1f</div>
+          </div>
+        </div>
+
+        <div style={messagesScroll}>
+          {[
+            { role: 'user', text: 'Read the auth README and tell me how refresh tokens are rotated.' },
+            { role: 'assistant', text: "I'll start by reading the README, then trace the refresh flow." },
+            { role: 'tool', text: "Read('server/auth/README.md')" },
+            { role: 'assistant', text: 'The README points at `RefreshSession::rotate` in `session.rs`. Let me read that next.' },
+            { role: 'tool', text: "Read('server/auth/session.rs', offset=120, limit=80)" },
+            {
+              role: 'assistant',
+              text:
+                'Rotation issues a new refresh token, marks the old one revoked in the same transaction, and ties them to the same `family_id`.',
+            },
+            { role: 'user', text: 'Walk through the postgres queries it runs and the order.' },
+            { role: 'assistant', text: "I'll trace through the function step by step:" },
+            { role: 'tool', text: "Grep('rotate', glob='server/auth/*.rs')" },
+          ].map((m, i) => (
+            <div key={i} style={msgRow}>
+              <div style={msgRoleLabel}>{m.role}</div>
+              <div style={{ ...msgBubble, ...bubbleColor(m.role) }}>{m.text}</div>
+            </div>
+          ))}
+        </div>
+
+        <div style={composer}>
+          <div style={composerToolbar}>
+            <button style={toolbarBtn} disabled>📎</button>
+            <button style={toolbarBtn} disabled>🎤</button>
+            <div style={{ flex: 1 }} />
+            {control}
+          </div>
+          <div style={composerRow}>
+            <div style={composerInput}>type a message…</div>
+            <button style={composerSend}>Send</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const heavyBudget = makeBudget({
+  conversation_tokens: 138_000,
+  tool_result_tokens: 5_400,
+});
+
+const lightBudget = makeBudget({
+  conversation_tokens: 38_400,
+  tool_result_tokens: 2_100,
+});
+
+export const HiddenWhenLow: StoryObj = {
+  name: '① Below threshold (control hidden)',
+  render: () => (
+    <StoreFixture budget={makeBudget()}>
+      <MockChat control={<ContextControl />} />
+    </StoreFixture>
+  ),
+};
+
+export const Idle: StoryObj = {
+  name: '② Idle at 73% (collapsed pill)',
+  render: () => (
+    <StoreFixture budget={heavyBudget}>
+      <MockChat control={<ContextControl />} />
+    </StoreFixture>
+  ),
+};
+
+export const Compacting: StoryObj = {
+  name: '③ Compacting (shimmer pill, modal suppressed)',
+  render: () => (
+    <StoreFixture budget={heavyBudget} isCompacting>
+      <MockChat control={<ContextControl />} />
+    </StoreFixture>
+  ),
+};
+
+export const ModalOpen: StoryObj = {
+  name: '④ Modal open (breakdown + Compact now)',
+  render: () => {
+    const Content = () => {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <MockChat
+            control={
+              <button
+                onClick={() => setOpen(true)}
+                style={{
+                  border: '1px solid #e5e7eb',
+                  borderRadius: 999,
+                  padding: '4px 10px',
+                  fontSize: 11,
+                  background: '#fff',
+                  cursor: 'pointer',
+                }}
+              >
+                ▰▰▰▰▰▱ 73%
+              </button>
+            }
+          />
+          {open && (
+            <ContextUsageModal onClose={() => setOpen(false)} onCompact={() => {}} />
+          )}
+        </>
+      );
+    };
+    return (
+      <StoreFixture budget={heavyBudget}>
+        <Content />
+      </StoreFixture>
+    );
+  },
+};
+
+export const ModalDuringCompaction: StoryObj = {
+  name: '⑤ Modal open during compaction',
+  render: () => {
+    const Content = () => {
+      const [open] = useState(true);
+      return (
+        <>
+          <MockChat control={<ContextControl />} />
+          {open && <ContextUsageModal onClose={() => {}} onCompact={() => {}} />}
+        </>
+      );
+    };
+    return (
+      <StoreFixture budget={heavyBudget} isCompacting>
+        <Content />
+      </StoreFixture>
+    );
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Layout styles
+// ────────────────────────────────────────────────────────────────────
+
+const shellOuter: React.CSSProperties = {
+  height: '100vh',
+  background: '#f3f4f6',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+  padding: 12,
+};
+
+const chatCol: React.CSSProperties = {
+  background: '#fff',
+  borderRadius: 10,
+  border: '1px solid #e5e7eb',
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  overflow: 'hidden',
+  maxWidth: 720,
+  margin: '0 auto',
+};
+
+const chatHeader: React.CSSProperties = {
+  padding: '12px 16px',
+  borderBottom: '1px solid #e5e7eb',
+};
+
+const headerTitle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#111827',
+};
+
+const headerSubtitle: React.CSSProperties = {
+  fontSize: 11,
+  color: '#6b7280',
+  marginTop: 2,
+};
+
+const messagesScroll: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '12px 16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const msgRow: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: 4 };
+const msgRoleLabel: React.CSSProperties = {
+  fontSize: 10,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+};
+
+const msgBubble: React.CSSProperties = {
+  borderRadius: 8,
+  padding: '8px 12px',
+  fontSize: 12,
+  lineHeight: 1.5,
+  whiteSpace: 'pre-wrap',
+};
+
+function bubbleColor(role: string): React.CSSProperties {
+  if (role === 'user') return { background: '#eff6ff', border: '1px solid #dbeafe', color: '#1e3a8a', alignSelf: 'flex-end', maxWidth: '85%' };
+  if (role === 'tool') return { background: '#f9fafb', border: '1px solid #e5e7eb', color: '#374151', fontFamily: 'ui-monospace, monospace', fontSize: 11, maxWidth: '90%' };
+  return { background: '#fff', border: '1px solid #e5e7eb', color: '#111827', maxWidth: '90%' };
+}
+
+const composer: React.CSSProperties = {
+  borderTop: '1px solid #e5e7eb',
+  padding: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+};
+
+const composerToolbar: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+};
+
+const toolbarBtn: React.CSSProperties = {
+  background: '#f9fafb',
+  border: '1px solid #e5e7eb',
+  borderRadius: 6,
+  padding: '4px 8px',
+  fontSize: 11,
+  cursor: 'pointer',
+  height: 26,
+};
+
+const composerRow: React.CSSProperties = { display: 'flex', gap: 8 };
+
+const composerInput: React.CSSProperties = {
+  flex: 1,
+  background: '#f9fafb',
+  border: '1px solid #e5e7eb',
+  borderRadius: 8,
+  padding: '8px 12px',
+  fontSize: 12,
+  color: '#9ca3af',
+};
+
+const composerSend: React.CSSProperties = {
+  background: '#1d4ed8',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 8,
+  padding: '8px 14px',
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: 'pointer',
+};

--- a/packages/react/src/components/ContextControl.tsx
+++ b/packages/react/src/components/ContextControl.tsx
@@ -1,0 +1,284 @@
+import { useState } from 'react';
+import { useChatStateStore } from '../stores/chatStateStore';
+import { ContextUsagePanel } from './ContextUsagePanel';
+import { contextUsageColor } from './contextColors';
+
+// Animation keyframes shared with the indicator/panel — registered once.
+if (typeof document !== 'undefined' && !document.getElementById('distri-ctx-control-anim')) {
+  const style = document.createElement('style');
+  style.id = 'distri-ctx-control-anim';
+  style.textContent = `
+    @keyframes distri-ctx-control-shimmer {
+      0%   { background-position: -60% 0; }
+      100% { background-position: 160% 0; }
+    }
+    @keyframes distri-ctx-control-spin {
+      to { transform: rotate(360deg); }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export interface ContextControlProps {
+  /**
+   * Override the store-driven `compact()` (testing / custom flows).
+   * The default reads `useChat().compact()` semantics off the store.
+   */
+  onCompact?: () => void | Promise<void>;
+  /**
+   * Don't render until utilization crosses this fraction (0–1). Defaults to
+   * 0.25 — most consumers don't care about context until the conversation
+   * is non-trivial, so we don't add chrome to short chats.
+   */
+  minUtilization?: number;
+  className?: string;
+}
+
+/**
+ * Opt-in chat control that surfaces context usage + compaction in the
+ * chat composer toolbar. Reads `chatStateStore` directly — drop it next
+ * to your composer (or wherever) and it lights up when the agent loop
+ * starts emitting `context_budget_update` events.
+ *
+ * - **Idle:** thin pill showing `78%` with a color-coded mini-bar.
+ * - **Mid-compaction:** same pill, with a horizontal shimmer + spinner;
+ *   the modal is suppressed (clicking is a no-op while in flight).
+ * - **Click:** opens `<ContextUsageModal />` with the per-component
+ *   breakdown, compaction history, and a "Compact now" button.
+ *
+ * Hides itself entirely when there's no budget yet, or when utilization
+ * is below `minUtilization` (default 25%).
+ *
+ * ```tsx
+ * <Chat threadId={tid} agent={agent} />
+ * <ContextControl />            // appears wherever you mount it
+ * ```
+ */
+export function ContextControl({
+  onCompact,
+  minUtilization = 0.25,
+  className = '',
+}: ContextControlProps) {
+  const budget = useChatStateStore((s) => s.contextBudget);
+  const isCompacting = useChatStateStore((s) => s.isCompacting);
+  const compactions = useChatStateStore((s) => s.compactionEvents);
+  const [open, setOpen] = useState(false);
+
+  if (!budget) return null;
+  const total = totalTokens(budget);
+  const window = budget.context_window_size || 0;
+  if (window === 0) return null;
+  const ratio = total / window;
+  if (ratio < minUtilization && !isCompacting && compactions.length === 0) {
+    return null;
+  }
+  const pct = Math.round(ratio * 100);
+  const color = contextUsageColor(ratio);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`distri-ctx-control ${className}`}
+        onClick={() => {
+          if (!isCompacting) setOpen(true);
+        }}
+        title={isCompacting ? 'Compaction in progress' : `Context: ${pct}% used — click for breakdown`}
+        style={{
+          ...pillStyle,
+          cursor: isCompacting ? 'wait' : 'pointer',
+          borderColor: isCompacting ? '#bfdbfe' : '#e5e7eb',
+          background: isCompacting ? '#eff6ff' : '#fff',
+        }}
+      >
+        {isCompacting ? (
+          <>
+            <span style={spinner} aria-hidden />
+            <span style={{ color: '#1d4ed8', fontWeight: 500 }}>Compacting…</span>
+          </>
+        ) : (
+          <>
+            <span style={{ ...miniBarBg }}>
+              <span
+                style={{
+                  ...miniBarFill,
+                  width: `${Math.min(pct, 100)}%`,
+                  background: color,
+                }}
+              />
+              <span aria-hidden style={{
+                position: 'absolute',
+                inset: 0,
+                background:
+                  'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.55) 50%, transparent 100%)',
+                backgroundSize: '60% 100%',
+                backgroundRepeat: 'no-repeat',
+                animation: isCompacting ? 'distri-ctx-control-shimmer 1.2s linear infinite' : undefined,
+                opacity: isCompacting ? 1 : 0,
+              }} />
+            </span>
+            <span style={pillLabel}>{pct}%</span>
+          </>
+        )}
+      </button>
+
+      {open && (
+        <ContextUsageModal
+          onClose={() => setOpen(false)}
+          onCompact={onCompact}
+        />
+      )}
+    </>
+  );
+}
+
+interface ContextUsageModalProps {
+  onClose: () => void;
+  onCompact?: () => void | Promise<void>;
+}
+
+/**
+ * Modal wrapper around `<ContextUsagePanel />`. Reads the same store the
+ * `<ContextControl />` button does, so the modal stays in sync with
+ * incoming events while it's open.
+ */
+export function ContextUsageModal({ onClose, onCompact }: ContextUsageModalProps) {
+  const budget = useChatStateStore((s) => s.contextBudget);
+  const isCompacting = useChatStateStore((s) => s.isCompacting);
+  const compactions = useChatStateStore((s) => s.compactionEvents);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      style={overlayStyle}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={dialogStyle}
+      >
+        <div style={dialogHeader}>
+          <div style={dialogTitle}>Context window</div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={closeButton}
+          >
+            ✕
+          </button>
+        </div>
+        <ContextUsagePanel
+          budget={budget}
+          compactions={compactions}
+          isCompacting={isCompacting}
+          onCompact={onCompact}
+        />
+      </div>
+    </div>
+  );
+}
+
+function totalTokens(b: NonNullable<ReturnType<typeof useChatStateStore.getState>['contextBudget']>): number {
+  return (
+    b.system_prompt_static_tokens +
+    b.system_prompt_dynamic_tokens +
+    b.tool_schema_tokens +
+    b.deferred_tool_tokens +
+    b.skill_listing_tokens +
+    b.conversation_tokens +
+    b.tool_result_tokens
+  );
+}
+
+const pillStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '4px 10px',
+  borderRadius: 999,
+  border: '1px solid #e5e7eb',
+  background: '#fff',
+  fontSize: 11,
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+  color: '#374151',
+  height: 26,
+};
+
+const pillLabel: React.CSSProperties = {
+  fontVariantNumeric: 'tabular-nums',
+  fontWeight: 500,
+};
+
+const miniBarBg: React.CSSProperties = {
+  position: 'relative',
+  display: 'inline-block',
+  width: 60,
+  height: 6,
+  background: '#f1f5f9',
+  borderRadius: 3,
+  overflow: 'hidden',
+};
+
+const miniBarFill: React.CSSProperties = {
+  display: 'block',
+  height: '100%',
+  borderRadius: 3,
+  transition: 'width 0.4s ease, background 0.3s ease',
+};
+
+const spinner: React.CSSProperties = {
+  display: 'inline-block',
+  width: 10,
+  height: 10,
+  borderRadius: '50%',
+  border: '2px solid #93c5fd',
+  borderTopColor: '#1d4ed8',
+  animation: 'distri-ctx-control-spin 0.8s linear infinite',
+};
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(15, 23, 42, 0.45)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+  padding: 16,
+};
+
+const dialogStyle: React.CSSProperties = {
+  width: 'min(460px, 100%)',
+  background: '#fff',
+  borderRadius: 12,
+  boxShadow: '0 25px 50px rgba(15, 23, 42, 0.25)',
+  padding: 16,
+  maxHeight: '90vh',
+  overflowY: 'auto',
+};
+
+const dialogHeader: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: 12,
+};
+
+const dialogTitle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#111827',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+
+const closeButton: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  fontSize: 16,
+  color: '#6b7280',
+  cursor: 'pointer',
+  padding: 4,
+  lineHeight: 1,
+};

--- a/packages/react/src/components/ContextIndicator.stories.tsx
+++ b/packages/react/src/components/ContextIndicator.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ContextIndicator } from './ContextIndicator';
+import type { ContextHealth } from '@distri/core';
+
+const meta: Meta<typeof ContextIndicator> = {
+  title: 'Compaction/ContextIndicator',
+  component: ContextIndicator,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 360, padding: 12, background: '#fff' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof ContextIndicator>;
+
+function makeHealth(
+  ratio: number,
+  opts: Partial<ContextHealth> = {},
+): ContextHealth {
+  const limit = 200_000;
+  return {
+    usage_ratio: ratio,
+    tokens_used: Math.round(limit * ratio),
+    tokens_limit: limit,
+    ...opts,
+  };
+}
+
+export const Empty: Story = {
+  name: 'Empty (no health yet)',
+  args: { contextHealth: null },
+};
+
+export const LowUsage: Story = {
+  name: 'Low usage (green)',
+  args: { contextHealth: makeHealth(0.18) },
+};
+
+export const Medium: Story = {
+  name: 'Medium usage (yellow)',
+  args: { contextHealth: makeHealth(0.55) },
+};
+
+export const Warning: Story = {
+  name: 'High usage (orange)',
+  args: { contextHealth: makeHealth(0.78) },
+};
+
+export const Critical: Story = {
+  name: 'Critical (red)',
+  args: { contextHealth: makeHealth(0.92) },
+};
+
+export const RecentlyCompacted: Story = {
+  name: 'Recently compacted (trim tier)',
+  args: {
+    contextHealth: makeHealth(0.32, {
+      last_compaction: {
+        type: 'context_compaction',
+        tier: 'trim',
+        tokens_before: 156_000,
+        tokens_after: 64_000,
+        entries_affected: 38,
+        context_limit: 200_000,
+        usage_ratio: 0.32,
+        source: 'auto',
+      },
+    }),
+  },
+};
+
+export const SummarizeTierCompaction: Story = {
+  name: 'Recently compacted (summarize tier)',
+  args: {
+    contextHealth: makeHealth(0.41, {
+      last_compaction: {
+        type: 'context_compaction',
+        tier: 'summarize',
+        tokens_before: 178_000,
+        tokens_after: 82_000,
+        entries_affected: 124,
+        context_limit: 200_000,
+        usage_ratio: 0.41,
+        source: 'manual',
+        summary: 'Summarized 124 turns of work into a structured recap.',
+      },
+    }),
+  },
+};
+
+export const Compacting: Story = {
+  name: 'Compaction in progress',
+  args: {
+    contextHealth: makeHealth(0.83),
+    isCompacting: true,
+  },
+};

--- a/packages/react/src/components/ContextIndicator.tsx
+++ b/packages/react/src/components/ContextIndicator.tsx
@@ -7,6 +7,24 @@ interface ContextIndicatorProps {
   className?: string;
 }
 
+// Animation keyframes shared with ContextUsagePanel — registered once.
+if (typeof document !== 'undefined' && !document.getElementById('distri-ctx-anim-indicator')) {
+  const style = document.createElement('style');
+  style.id = 'distri-ctx-anim-indicator';
+  style.textContent = `
+    @keyframes distri-ctx-indicator-shimmer {
+      0%   { background-position: -60% 0; }
+      100% { background-position: 160% 0; }
+    }
+    @keyframes distri-ctx-indicator-dots {
+      0%   { opacity: 0.3; }
+      50%  { opacity: 1; }
+      100% { opacity: 0.3; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
 /**
  * Visual indicator for context window health.
  *
@@ -32,7 +50,17 @@ export function ContextIndicator({
 
   return (
     <div className={`distri-context-indicator ${className}`} title={`Context: ${percentage}% used`}>
-      <div className="distri-context-bar-bg" style={{ width: '100%', height: 4, background: '#e5e7eb', borderRadius: 2, overflow: 'hidden' }}>
+      <div
+        className="distri-context-bar-bg"
+        style={{
+          width: '100%',
+          height: 4,
+          background: '#e5e7eb',
+          borderRadius: 2,
+          overflow: 'hidden',
+          position: 'relative',
+        }}
+      >
         <div
           className="distri-context-bar-fill"
           style={{
@@ -43,18 +71,45 @@ export function ContextIndicator({
             transition: 'width 0.5s ease, background 0.3s ease',
           }}
         />
-      </div>
-      <div className="distri-context-label" style={{ fontSize: 11, color: '#6b7280', marginTop: 2, display: 'flex', justifyContent: 'space-between' }}>
-        <span>
-          {isCompacting ? 'Compacting...' : `${percentage}% context used`}
-        </span>
-        {tierLabel && (
-          <span style={{ opacity: 0.7 }}>
-            Last: {tierLabel}
-          </span>
+        {isCompacting && (
+          <div
+            aria-hidden
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background:
+                'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.7) 50%, transparent 100%)',
+              backgroundSize: '60% 100%',
+              backgroundRepeat: 'no-repeat',
+              animation: 'distri-ctx-indicator-shimmer 1.2s linear infinite',
+            }}
+          />
         )}
+      </div>
+      <div
+        className="distri-context-label"
+        style={{
+          fontSize: 11,
+          color: '#6b7280',
+          marginTop: 2,
+          display: 'flex',
+          justifyContent: 'space-between',
+        }}
+      >
+        <span style={isCompacting ? { color: '#1d4ed8', fontWeight: 500 } : undefined}>
+          {isCompacting ? (
+            <>
+              Compacting
+              <span style={{ animation: 'distri-ctx-indicator-dots 1.4s ease-in-out infinite' }}>.</span>
+              <span style={{ animation: 'distri-ctx-indicator-dots 1.4s ease-in-out 0.2s infinite' }}>.</span>
+              <span style={{ animation: 'distri-ctx-indicator-dots 1.4s ease-in-out 0.4s infinite' }}>.</span>
+            </>
+          ) : (
+            `${percentage}% context used`
+          )}
+        </span>
+        {tierLabel && <span style={{ opacity: 0.7 }}>Last: {tierLabel}</span>}
       </div>
     </div>
   );
 }
-

--- a/packages/react/src/components/ContextIndicator.tsx
+++ b/packages/react/src/components/ContextIndicator.tsx
@@ -1,4 +1,5 @@
 import type { ContextHealth } from '@distri/core';
+import { contextUsageColor } from './contextColors';
 
 interface ContextIndicatorProps {
   contextHealth: ContextHealth | null;
@@ -26,7 +27,7 @@ export function ContextIndicator({
   if (!contextHealth) return null;
 
   const percentage = Math.round(contextHealth.usage_ratio * 100);
-  const color = getColor(contextHealth.usage_ratio);
+  const color = contextUsageColor(contextHealth.usage_ratio);
   const tierLabel = contextHealth.last_compaction?.tier;
 
   return (
@@ -57,9 +58,3 @@ export function ContextIndicator({
   );
 }
 
-function getColor(ratio: number): string {
-  if (ratio < 0.5) return '#22c55e';  // green
-  if (ratio < 0.7) return '#eab308';  // yellow
-  if (ratio < 0.85) return '#f97316'; // orange
-  return '#ef4444';                    // red
-}

--- a/packages/react/src/components/ContextUsagePanel.stories.tsx
+++ b/packages/react/src/components/ContextUsagePanel.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ContextUsagePanel } from './ContextUsagePanel';
+import type { ContextBudget } from '@distri/core';
+
+const meta: Meta<typeof ContextUsagePanel> = {
+  title: 'Compaction/ContextUsagePanel',
+  component: ContextUsagePanel,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof ContextUsagePanel>;
+
+function makeBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
+  return {
+    system_prompt_static_tokens: 4_100,
+    system_prompt_dynamic_tokens: 1_200,
+    tool_schema_tokens: 5_400,
+    deferred_tool_tokens: 800,
+    skill_listing_tokens: 600,
+    conversation_tokens: 1_500,
+    tool_result_tokens: 320,
+    context_window_size: 200_000,
+    static_prefix_cache_hit: true,
+    ...overrides,
+  };
+}
+
+export const Empty: Story = {
+  name: 'Empty (first render)',
+  args: { budget: undefined, compactions: [] },
+};
+
+export const FreshConversation: Story = {
+  name: 'Fresh conversation',
+  args: {
+    budget: makeBudget(),
+    compactions: [],
+    onCompact: () => {},
+  },
+};
+
+export const Warning: Story = {
+  name: 'Warning band (78%)',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 138_000,
+      tool_result_tokens: 5_400,
+    }),
+    compactions: [],
+    onCompact: () => {},
+  },
+};
+
+export const Critical: Story = {
+  name: 'Critical (92%)',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 168_000,
+      tool_result_tokens: 8_200,
+      static_prefix_cache_hit: false,
+    }),
+    compactions: [],
+    onCompact: () => {},
+  },
+};
+
+export const Compacting: Story = {
+  name: 'Compaction in flight',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 152_000,
+      tool_result_tokens: 6_800,
+    }),
+    compactions: [],
+    isCompacting: true,
+    onCompact: () => {},
+  },
+};
+
+export const WithCompactionLog: Story = {
+  name: 'After several compactions',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 38_400,
+      tool_result_tokens: 2_100,
+    }),
+    compactions: [
+      {
+        ts: Date.now() - 12 * 60_000,
+        before: 158_000,
+        after: 64_000,
+        tier: 'trim',
+        source: 'auto',
+      },
+      {
+        ts: Date.now() - 6 * 60_000,
+        before: 172_000,
+        after: 82_000,
+        tier: 'summarize',
+        source: 'auto',
+      },
+      {
+        ts: Date.now() - 90_000,
+        before: 124_000,
+        after: 41_000,
+        tier: 'trim',
+        source: 'manual',
+      },
+    ],
+    onCompact: () => {},
+  },
+};
+
+export const EmergencyReset: Story = {
+  name: 'Emergency reset just fired',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 6_400,
+      tool_result_tokens: 800,
+      static_prefix_cache_hit: false,
+    }),
+    compactions: [
+      {
+        ts: Date.now() - 2_000,
+        before: 192_000,
+        after: 12_400,
+        tier: 'reset',
+        source: 'auto',
+      },
+    ],
+    onCompact: () => {},
+  },
+};
+
+export const WithoutCompactButton: Story = {
+  name: 'Read-only (no Compact button)',
+  args: {
+    budget: makeBudget({
+      conversation_tokens: 88_000,
+    }),
+    compactions: [],
+    // onCompact omitted → button hidden
+  },
+};

--- a/packages/react/src/components/ContextUsagePanel.tsx
+++ b/packages/react/src/components/ContextUsagePanel.tsx
@@ -1,4 +1,5 @@
 import type { ContextBudget } from '@distri/core';
+import { contextUsageColor } from './contextColors';
 
 export interface CompactionLogItem {
   ts: number;
@@ -51,7 +52,7 @@ export function ContextUsagePanel({
   const total = totalTokens(budget);
   const window = budget.context_window_size || 0;
   const pct = window > 0 ? Math.round((total / window) * 100) : 0;
-  const color = pctColor(pct / 100);
+  const color = contextUsageColor(pct / 100);
 
   const rows: Array<[string, number]> = [
     ['Static prompt', budget.system_prompt_static_tokens],
@@ -185,13 +186,6 @@ function totalTokens(b: ContextBudget): number {
     b.conversation_tokens +
     b.tool_result_tokens
   );
-}
-
-function pctColor(ratio: number): string {
-  if (ratio < 0.5) return '#22c55e';
-  if (ratio < 0.7) return '#eab308';
-  if (ratio < 0.85) return '#f97316';
-  return '#ef4444';
 }
 
 function fmt(n: number): string {

--- a/packages/react/src/components/ContextUsagePanel.tsx
+++ b/packages/react/src/components/ContextUsagePanel.tsx
@@ -1,6 +1,23 @@
 import type { ContextBudget } from '@distri/core';
 import { contextUsageColor } from './contextColors';
 
+// One-time keyframes injection so the in-flight compaction shimmer + spinner
+// animate without pulling in a CSS dependency. SSR-safe (guards on document).
+if (typeof document !== 'undefined' && !document.getElementById('distri-ctx-anim')) {
+  const style = document.createElement('style');
+  style.id = 'distri-ctx-anim';
+  style.textContent = `
+    @keyframes distri-ctx-shimmer {
+      0%   { background-position: -60% 0; }
+      100% { background-position: 160% 0; }
+    }
+    @keyframes distri-ctx-spin {
+      to { transform: rotate(360deg); }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
 export interface CompactionLogItem {
   ts: number;
   before: number;
@@ -89,7 +106,14 @@ export function ContextUsagePanel({
         )}
       </div>
 
-      <div style={barBg}>
+      {isCompacting && (
+        <div style={compactingBanner}>
+          <span style={spinnerStyle} aria-hidden />
+          <span>Summarizing earlier turns to free context…</span>
+        </div>
+      )}
+
+      <div style={{ ...barBg, position: 'relative' }}>
         <div
           style={{
             ...barFill,
@@ -97,6 +121,7 @@ export function ContextUsagePanel({
             background: color,
           }}
         />
+        {isCompacting && <div style={barShimmer} aria-hidden />}
       </div>
 
       <div style={breakdownGrid}>
@@ -262,6 +287,39 @@ const barBgSmall: React.CSSProperties = {
 const barFill: React.CSSProperties = {
   height: '100%',
   transition: 'width 0.4s ease, background 0.3s ease',
+};
+
+const barShimmer: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  background:
+    'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.55) 50%, transparent 100%)',
+  backgroundSize: '60% 100%',
+  backgroundRepeat: 'no-repeat',
+  animation: 'distri-ctx-shimmer 1.2s linear infinite',
+};
+
+const compactingBanner: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  marginBottom: 8,
+  padding: '6px 10px',
+  borderRadius: 6,
+  background: '#eff6ff',
+  color: '#1d4ed8',
+  fontSize: 11,
+  border: '1px solid #bfdbfe',
+};
+
+const spinnerStyle: React.CSSProperties = {
+  display: 'inline-block',
+  width: 10,
+  height: 10,
+  borderRadius: '50%',
+  border: '2px solid #93c5fd',
+  borderTopColor: '#1d4ed8',
+  animation: 'distri-ctx-spin 0.8s linear infinite',
 };
 
 const breakdownGrid: React.CSSProperties = {

--- a/packages/react/src/components/ContextUsagePanel.tsx
+++ b/packages/react/src/components/ContextUsagePanel.tsx
@@ -1,0 +1,320 @@
+import type { ContextBudget } from '@distri/core';
+
+export interface CompactionLogItem {
+  ts: number;
+  before: number;
+  after: number;
+  tier: 'trim' | 'summarize' | 'reset';
+  source: 'auto' | 'manual';
+}
+
+interface ContextUsagePanelProps {
+  budget?: ContextBudget;
+  compactions?: CompactionLogItem[];
+  isCompacting?: boolean;
+  onCompact?: () => void;
+  className?: string;
+}
+
+/**
+ * Detailed context usage breakdown for the compaction spec's
+ * `<ContextIndicator />` companion panel. Renders the per-component
+ * `ContextBudget` columns the CLI status line surfaces, plus the
+ * compaction event log this session.
+ *
+ * Pairs with `useChatStateStore`:
+ *
+ * ```tsx
+ * const budget = useChatStateStore(s => s.contextBudget);
+ * const compactions = useChatStateStore(s => s.compactionEvents);
+ * const { compact } = useChat({ agent, threadId });
+ * return <ContextUsagePanel budget={budget} compactions={compactions} onCompact={compact} />;
+ * ```
+ */
+export function ContextUsagePanel({
+  budget,
+  compactions = [],
+  isCompacting = false,
+  onCompact,
+  className = '',
+}: ContextUsagePanelProps) {
+  if (!budget) {
+    return (
+      <div className={`distri-ctx-panel ${className}`} style={panelStyle}>
+        <div style={{ ...labelStyle, opacity: 0.7 }}>
+          Context usage will appear after the first turn.
+        </div>
+      </div>
+    );
+  }
+
+  const total = totalTokens(budget);
+  const window = budget.context_window_size || 0;
+  const pct = window > 0 ? Math.round((total / window) * 100) : 0;
+  const color = pctColor(pct / 100);
+
+  const rows: Array<[string, number]> = [
+    ['Static prompt', budget.system_prompt_static_tokens],
+    ['Dynamic prompt', budget.system_prompt_dynamic_tokens],
+    ['Tool schemas', budget.tool_schema_tokens],
+    ['Deferred tools', budget.deferred_tool_tokens],
+    ['Skill listing', budget.skill_listing_tokens],
+    ['Conversation', budget.conversation_tokens],
+    ['Tool results', budget.tool_result_tokens],
+  ];
+
+  return (
+    <div className={`distri-ctx-panel ${className}`} style={panelStyle}>
+      <div style={headerRow}>
+        <div>
+          <div style={titleStyle}>Context usage</div>
+          <div style={subtitleStyle}>
+            {fmt(total)} / {fmt(window)} tokens ({pct}%)
+          </div>
+        </div>
+        {onCompact && (
+          <button
+            type="button"
+            onClick={onCompact}
+            disabled={isCompacting}
+            style={{
+              ...buttonStyle,
+              opacity: isCompacting ? 0.6 : 1,
+              cursor: isCompacting ? 'wait' : 'pointer',
+            }}
+          >
+            {isCompacting ? 'Compacting…' : 'Compact now'}
+          </button>
+        )}
+      </div>
+
+      <div style={barBg}>
+        <div
+          style={{
+            ...barFill,
+            width: `${Math.min(pct, 100)}%`,
+            background: color,
+          }}
+        />
+      </div>
+
+      <div style={breakdownGrid}>
+        {rows.map(([label, value]) => (
+          <BreakdownRow
+            key={label}
+            label={label}
+            value={value}
+            window={window || 1}
+            color={color}
+          />
+        ))}
+      </div>
+
+      {budget.static_prefix_cache_hit && (
+        <div style={pillStyle}>
+          ✓ static prefix cached
+        </div>
+      )}
+
+      {compactions.length > 0 && (
+        <div style={{ marginTop: 12 }}>
+          <div style={{ ...labelStyle, marginBottom: 6 }}>
+            Compaction events
+          </div>
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+            {compactions.slice(-5).reverse().map((c, i) => (
+              <li key={`${c.ts}-${i}`} style={logRow}>
+                <span style={tierBadge(c.tier)}>{c.tier}</span>
+                <span style={{ opacity: 0.7, marginLeft: 6 }}>{c.source}</span>
+                <span style={{ marginLeft: 'auto', fontVariantNumeric: 'tabular-nums' }}>
+                  {fmt(c.before)} → {fmt(c.after)} ({reductionPct(c.before, c.after)}% saved)
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BreakdownRow({
+  label,
+  value,
+  window,
+  color,
+}: {
+  label: string;
+  value: number;
+  window: number;
+  color: string;
+}) {
+  const pct = window > 0 ? (value / window) * 100 : 0;
+  return (
+    <div style={breakdownRow}>
+      <span style={{ fontSize: 11, color: '#6b7280', flexShrink: 0, width: 110 }}>
+        {label}
+      </span>
+      <div style={{ flex: 1, marginInline: 8 }}>
+        <div style={{ ...barBgSmall }}>
+          <div style={{ width: `${Math.min(pct, 100)}%`, height: '100%', background: color, borderRadius: 2 }} />
+        </div>
+      </div>
+      <span
+        style={{
+          fontSize: 11,
+          color: '#374151',
+          fontVariantNumeric: 'tabular-nums',
+          width: 60,
+          textAlign: 'right',
+        }}
+      >
+        {fmt(value)}
+      </span>
+    </div>
+  );
+}
+
+function totalTokens(b: ContextBudget): number {
+  return (
+    b.system_prompt_static_tokens +
+    b.system_prompt_dynamic_tokens +
+    b.tool_schema_tokens +
+    b.deferred_tool_tokens +
+    b.skill_listing_tokens +
+    b.conversation_tokens +
+    b.tool_result_tokens
+  );
+}
+
+function pctColor(ratio: number): string {
+  if (ratio < 0.5) return '#22c55e';
+  if (ratio < 0.7) return '#eab308';
+  if (ratio < 0.85) return '#f97316';
+  return '#ef4444';
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return String(n);
+}
+
+function reductionPct(before: number, after: number): number {
+  if (before <= 0) return 0;
+  return Math.round((1 - after / before) * 100);
+}
+
+const panelStyle: React.CSSProperties = {
+  border: '1px solid #e5e7eb',
+  borderRadius: 8,
+  padding: 12,
+  background: '#fff',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+
+const headerRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  marginBottom: 8,
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#111827',
+};
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: '#6b7280',
+  marginTop: 2,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: '#6b7280',
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+};
+
+const buttonStyle: React.CSSProperties = {
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  background: '#f9fafb',
+  padding: '4px 10px',
+  fontSize: 11,
+  color: '#374151',
+};
+
+const barBg: React.CSSProperties = {
+  width: '100%',
+  height: 6,
+  background: '#e5e7eb',
+  borderRadius: 3,
+  overflow: 'hidden',
+  marginBottom: 12,
+};
+
+const barBgSmall: React.CSSProperties = {
+  width: '100%',
+  height: 3,
+  background: '#f1f5f9',
+  borderRadius: 2,
+  overflow: 'hidden',
+};
+
+const barFill: React.CSSProperties = {
+  height: '100%',
+  transition: 'width 0.4s ease, background 0.3s ease',
+};
+
+const breakdownGrid: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+};
+
+const breakdownRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+};
+
+const pillStyle: React.CSSProperties = {
+  marginTop: 10,
+  fontSize: 10,
+  color: '#15803d',
+  background: '#dcfce7',
+  borderRadius: 999,
+  padding: '2px 8px',
+  display: 'inline-block',
+};
+
+const logRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  padding: '4px 0',
+  fontSize: 11,
+  color: '#374151',
+  borderTop: '1px dashed #e5e7eb',
+};
+
+function tierBadge(tier: 'trim' | 'summarize' | 'reset'): React.CSSProperties {
+  const colors = {
+    trim: { bg: '#dbeafe', fg: '#1d4ed8' },
+    summarize: { bg: '#fef3c7', fg: '#a16207' },
+    reset: { bg: '#fee2e2', fg: '#b91c1c' },
+  } as const;
+  const c = colors[tier];
+  return {
+    fontSize: 10,
+    fontWeight: 600,
+    background: c.bg,
+    color: c.fg,
+    borderRadius: 4,
+    padding: '1px 6px',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  };
+}

--- a/packages/react/src/components/contextColors.ts
+++ b/packages/react/src/components/contextColors.ts
@@ -1,0 +1,12 @@
+/**
+ * Threshold color for a context-usage ratio, shared by `<ContextIndicator />`
+ * and `<ContextUsagePanel />`. Returns a hex literal so both inline-styled
+ * components can use it directly. Keep in sync with the bands the server's
+ * `ContextBudget::is_warning()` / `is_critical()` checks use.
+ */
+export function contextUsageColor(ratio: number): string {
+  if (ratio < 0.5) return '#22c55e'; // green
+  if (ratio < 0.7) return '#eab308'; // yellow
+  if (ratio < 0.85) return '#f97316'; // orange
+  return '#ef4444'; // red
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/Toast';
 export * from './components/AuthLoading';
 export * from './components/AskFollowUp';
 export * from './components/ContextIndicator';
+export * from './components/ContextUsagePanel';
 
 // Provider exports
 export * from './DistriProvider';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,6 +21,7 @@ export * from './components/AuthLoading';
 export * from './components/AskFollowUp';
 export * from './components/ContextIndicator';
 export * from './components/ContextUsagePanel';
+export * from './components/ContextControl';
 
 // Provider exports
 export * from './DistriProvider';

--- a/packages/react/src/stores/chatStateStore.ts
+++ b/packages/react/src/stores/chatStateStore.ts
@@ -172,11 +172,18 @@ export interface ChatState {
   /** Whether the latest budget update crossed the critical threshold (≥90%). */
   contextCritical?: boolean;
   /**
-   * Compaction events received this session, in arrival order. Used by
+   * Compaction events received this session, in arrival order. Capped at
+   * 50 entries to bound memory on long-lived chats. Used by
    * `<ContextIndicator />` to show "Compacted N times" and surface a recent
    * before/after slot in the breakdown popover.
    */
   compactionEvents: CompactionLogEntry[];
+  /**
+   * Set while a `compaction_requested` event is in flight; cleared by the
+   * matching `context_compaction` arrival or by `useChat().compact()`'s
+   * failure handler. Drives the 'Compacting…' UI in `<ContextUsagePanel />`.
+   */
+  isCompacting?: boolean;
 }
 
 export interface CompactionLogEntry {
@@ -286,6 +293,7 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
   contextWarning: false,
   contextCritical: false,
   compactionEvents: [],
+  isCompacting: false,
   tools: {
     tools: [],
     agent_tools: new Map(),
@@ -868,18 +876,36 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
 
         case 'context_compaction': {
           const data: any = (event as any).data || {};
+          // Prefer the wire-level timestamp so the badge reflects when
+          // compaction ran on the server, not when the SSE event was
+          // decoded on the client. Falls back to Date.now() for offline
+          // / replay scenarios where the envelope is missing.
+          const wireTs = Number((event as any).timestamp);
           const entry: CompactionLogEntry = {
-            ts: Date.now(),
+            ts: Number.isFinite(wireTs) && wireTs > 0 ? wireTs : Date.now(),
             before: Number(data.tokens_before ?? 0),
             after: Number(data.tokens_after ?? 0),
             tier: (data.tier as ContextCompactionEvent['tier']) ?? 'trim',
             source: (data.source as 'auto' | 'manual') ?? 'auto',
           };
           set(state => ({
-            compactionEvents: [...state.compactionEvents, entry],
+            // Cap the log to the last 50 entries — long-lived sessions
+            // would otherwise grow it unboundedly and fan re-renders out
+            // to every subscriber on each compaction.
+            compactionEvents: [...state.compactionEvents, entry].slice(-50),
             // The compaction event also carries the post-compact budget snapshot.
             contextBudget: (data.context_budget as ContextBudget | undefined) ?? state.contextBudget,
+            // A new compaction event resolves any in-flight 'compacting…' state.
+            isCompacting: false,
           }));
+          break;
+        }
+
+        case 'compaction_requested' as any: {
+          // Pre-compaction signal — flip the in-flight flag so UIs can
+          // render a 'compacting…' indicator until the matching
+          // context_compaction event arrives.
+          set({ isCompacting: true });
           break;
         }
 
@@ -1278,6 +1304,7 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
       contextWarning: false,
       contextCritical: false,
       compactionEvents: [],
+      isCompacting: false,
     });
   },
 
@@ -1315,6 +1342,17 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
         if (plan.runId === taskId) {
           newState.plans.delete(planId);
         }
+      }
+
+      // If we're clearing the currently-tracked task, also drop its
+      // context-budget snapshot and compaction log — leaving them would
+      // render stale numbers for the next task on the same thread.
+      if (state.currentTaskId === taskId) {
+        newState.contextBudget = undefined;
+        newState.contextWarning = false;
+        newState.contextCritical = false;
+        newState.compactionEvents = [];
+        newState.isCompacting = false;
       }
 
       return newState;

--- a/packages/react/src/stores/chatStateStore.ts
+++ b/packages/react/src/stores/chatStateStore.ts
@@ -23,6 +23,8 @@ import {
   TodosUpdatedEvent,
   createSuccessfulToolResult,
   createFailedToolResult,
+  ContextBudget,
+  ContextCompactionEvent,
 } from '@distri/core';
 import { DistriAnyTool, DistriUiTool, ToolCallStatus, RenderingMode, ChatSessionSettings } from '../types';
 import { StreamingIndicator } from '@/components/renderers/ThinkingRenderer';
@@ -162,6 +164,27 @@ export interface ChatState {
    * Reset to `[]` whenever todos are cleared.
    */
   lastTodoChanges: TodoChange[];
+
+  /** Latest `ContextBudget` from a `context_budget_update` event. */
+  contextBudget?: ContextBudget;
+  /** Whether the latest budget update crossed the warning threshold (≥80%). */
+  contextWarning?: boolean;
+  /** Whether the latest budget update crossed the critical threshold (≥90%). */
+  contextCritical?: boolean;
+  /**
+   * Compaction events received this session, in arrival order. Used by
+   * `<ContextIndicator />` to show "Compacted N times" and surface a recent
+   * before/after slot in the breakdown popover.
+   */
+  compactionEvents: CompactionLogEntry[];
+}
+
+export interface CompactionLogEntry {
+  ts: number;
+  before: number;
+  after: number;
+  tier: ContextCompactionEvent['tier'];
+  source: 'auto' | 'manual';
 }
 
 type ChatStateTool = DistriAnyTool & {
@@ -259,6 +282,10 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
   browserStreamUrl: undefined,
   todos: [],
   lastTodoChanges: [],
+  contextBudget: undefined,
+  contextWarning: false,
+  contextCritical: false,
+  compactionEvents: [],
   tools: {
     tools: [],
     agent_tools: new Map(),
@@ -829,6 +856,33 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
           break;
         }
 
+        case 'context_budget_update': {
+          const data: any = (event as any).data || {};
+          set({
+            contextBudget: data.budget as ContextBudget | undefined,
+            contextWarning: !!data.is_warning,
+            contextCritical: !!data.is_critical,
+          });
+          break;
+        }
+
+        case 'context_compaction': {
+          const data: any = (event as any).data || {};
+          const entry: CompactionLogEntry = {
+            ts: Date.now(),
+            before: Number(data.tokens_before ?? 0),
+            after: Number(data.tokens_after ?? 0),
+            tier: (data.tier as ContextCompactionEvent['tier']) ?? 'trim',
+            source: (data.source as 'auto' | 'manual') ?? 'auto',
+          };
+          set(state => ({
+            compactionEvents: [...state.compactionEvents, entry],
+            // The compaction event also carries the post-compact budget snapshot.
+            contextBudget: (data.context_budget as ContextBudget | undefined) ?? state.contextBudget,
+          }));
+          break;
+        }
+
         default:
           // Handle any other events
           break;
@@ -1220,6 +1274,10 @@ export const useChatStateStore = create<ChatStateStore>((set, get) => ({
       browserStreamUrl: undefined,
       todos: [],
       lastTodoChanges: [],
+      contextBudget: undefined,
+      contextWarning: false,
+      contextCritical: false,
+      compactionEvents: [],
     });
   },
 

--- a/packages/react/src/useChat.ts
+++ b/packages/react/src/useChat.ts
@@ -376,16 +376,28 @@ export function useChat({
     setLoading(false);
   }, [failAllPendingToolCalls, setStreamingIndicator, setStreaming, setLoading]);
 
+  const compactingRef = useRef(false);
   const compact = useCallback(async () => {
     const taskId = currentTaskId;
     if (!agent || !taskId) {
       console.warn('[useChat] compact() called with no active task — nothing to compact');
       return;
     }
+    // Reentrancy guard: a second click (or double-bound handler) would
+    // otherwise fire a duplicate POST while the first is still in flight.
+    if (compactingRef.current) return;
+    compactingRef.current = true;
+    useChatStateStore.setState({ isCompacting: true });
     try {
       await agent.compact(taskId);
     } catch (err) {
+      // Surface the error so onError handlers can render it, and clear
+      // the in-flight flag — the matching context_compaction event will
+      // not arrive on failure.
+      useChatStateStore.setState({ isCompacting: false });
       onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      compactingRef.current = false;
     }
   }, [agent, currentTaskId]);
 

--- a/packages/react/src/useChat.ts
+++ b/packages/react/src/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Agent, DistriBaseTool, DistriChatMessage, DistriClient, DistriMessage, ToolExecutionOptions, PartMetadata } from '@distri/core';
+import { Agent, DistriBaseTool, DistriChatMessage, DistriClient, DistriMessage, ToolExecutionOptions, PartMetadata, CompactTaskResult } from '@distri/core';
 import {
   DistriPart,
   InvokeContext,
@@ -44,12 +44,15 @@ export interface UseChatReturn {
   stopStreaming: () => void;
   addMessage: (message: DistriChatMessage) => void;
   /**
-   * Manually run compaction on the current task. Resolves when the server
-   * has applied the compactor; the resulting `context_compaction` event
-   * arrives over the stream and updates `useChatStateStore.compactionEvents`.
-   * No-op (with a warning) when there is no active task to compact.
+   * Manually run compaction on the current task. Resolves with the typed
+   * `CompactTaskResult` body the server returned — token counts are
+   * available synchronously here, while the streaming
+   * `context_compaction` event still arrives over the stream and updates
+   * `useChatStateStore.compactionEvents` for observers that prefer the
+   * event-driven path. Resolves with `undefined` when there is no
+   * active task to compact.
    */
-  compact: () => Promise<void>;
+  compact: () => Promise<CompactTaskResult | undefined>;
 }
 
 export function useChat({
@@ -377,25 +380,48 @@ export function useChat({
   }, [failAllPendingToolCalls, setStreamingIndicator, setStreaming, setLoading]);
 
   const compactingRef = useRef(false);
-  const compact = useCallback(async () => {
+  const compact = useCallback(async (): Promise<CompactTaskResult | undefined> => {
     const taskId = currentTaskId;
     if (!agent || !taskId) {
       console.warn('[useChat] compact() called with no active task — nothing to compact');
-      return;
+      return undefined;
     }
     // Reentrancy guard: a second click (or double-bound handler) would
     // otherwise fire a duplicate POST while the first is still in flight.
-    if (compactingRef.current) return;
+    if (compactingRef.current) return undefined;
     compactingRef.current = true;
     useChatStateStore.setState({ isCompacting: true });
     try {
-      await agent.compact(taskId);
+      const result = await agent.compact(taskId);
+      // Mirror the compaction event into the store so observers that
+      // depend on `compactionEvents` see the result even before the
+      // streaming `context_compaction` event arrives (or in case it
+      // races past `useChat` after compactingRef has cleared).
+      if (result?.compacted && result.tier) {
+        useChatStateStore.setState(s => ({
+          isCompacting: false,
+          compactionEvents: [
+            ...s.compactionEvents,
+            {
+              ts: Date.now(),
+              before: result.tokens_before ?? 0,
+              after: result.tokens_after ?? 0,
+              tier: result.tier!,
+              source: 'manual' as const,
+            },
+          ].slice(-50),
+        }));
+      } else {
+        useChatStateStore.setState({ isCompacting: false });
+      }
+      return result;
     } catch (err) {
       // Surface the error so onError handlers can render it, and clear
       // the in-flight flag — the matching context_compaction event will
       // not arrive on failure.
       useChatStateStore.setState({ isCompacting: false });
       onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+      return undefined;
     } finally {
       compactingRef.current = false;
     }

--- a/packages/react/src/useChat.ts
+++ b/packages/react/src/useChat.ts
@@ -43,6 +43,13 @@ export interface UseChatReturn {
   hasPendingToolCalls: () => boolean;
   stopStreaming: () => void;
   addMessage: (message: DistriChatMessage) => void;
+  /**
+   * Manually run compaction on the current task. Resolves when the server
+   * has applied the compactor; the resulting `context_compaction` event
+   * arrives over the stream and updates `useChatStateStore.compactionEvents`.
+   * No-op (with a warning) when there is no active task to compact.
+   */
+  compact: () => Promise<void>;
 }
 
 export function useChat({
@@ -369,6 +376,19 @@ export function useChat({
     setLoading(false);
   }, [failAllPendingToolCalls, setStreamingIndicator, setStreaming, setLoading]);
 
+  const compact = useCallback(async () => {
+    const taskId = currentTaskId;
+    if (!agent || !taskId) {
+      console.warn('[useChat] compact() called with no active task — nothing to compact');
+      return;
+    }
+    try {
+      await agent.compact(taskId);
+    } catch (err) {
+      onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+    }
+  }, [agent, currentTaskId]);
+
   // Combined display array: persisted history (from parent) first, live
   // optimistic + streamed messages from the store after. Memoised so
   // downstream effects keyed on `messages` don't fire on every render.
@@ -389,5 +409,6 @@ export function useChat({
     hasPendingToolCalls,
     stopStreaming,
     addMessage,
+    compact,
   };
 }


### PR DESCRIPTION
## Summary

Introduces built-in system slash commands (`/compact`, `/usage`, `/clear`, `/help`) that all agents receive automatically, plus a manual compaction endpoint and CLI support for triggering context compaction on demand.

## Key Changes

**distri-types/src/channel_commands.rs**
- Added `system_commands()` function that returns the four built-in slash commands
- Added `resolve_commands(agent)` to merge system commands with agent-declared commands, with agent commands shadowing system ones by name
- Added `is_system_command(name)` helper for routers to short-circuit these commands
- Added comprehensive tests for command resolution and shadowing behavior

**distri-types/src/agent.rs**
- Added `CompactionConfig` struct for per-agent auto-compaction settings (`auto_threshold`, `keep_recent_entries`, `prompt_version`)
- Added `compaction` field to `StandardDefinition` to allow agents to customize compaction behavior

**distri-types/src/events.rs**
- Extended `ContextCompaction` event with `source` field ("auto" or "manual") and `duration_ms` for observability
- Added new `CompactionRequested` event to distinguish manual vs auto triggers

**server/distri-core/src/agent/context.rs**
- Refactored compaction logic: split `evaluate_compaction()` into public method and private `run_compaction(source, force)` helper
- Added `force_compaction()` for unconditional compaction (used by `/compact` endpoint)
- Force path escalates to Tier 1 Trim if no tier was selected, ensuring something always happens
- Added timing instrumentation and improved logging with source attribution

**server/distri-core/src/agent/orchestrator.rs**
- Added `compact_task(task_id)` public method to trigger manual compaction for a task
- Builds minimal `ExecutorContext` with task/thread context and calls `force_compaction()`
- Mechanical compaction (Trim/Reset) runs entirely on stores without LLM

**server/distri-server/src/routes.rs**
- Added `POST /v1/tasks/{task_id}/compact` endpoint via `compact_task_handler`
- Returns JSON with compaction result: `compacted` bool, tier, token counts, entries affected, usage ratio

**distri/src/client.rs**
- Added `compact_task(task_id)` async method to call the server's compact endpoint
- Added `list_tasks(thread_id, limit, offset)` to query tasks with optional filtering and pagination

**distri-cli/src/chat.rs**
- Implemented `/compact` slash command: finds most recent task on thread, calls server endpoint, displays token reduction
- Implemented `/usage` slash command: displays context breakdown from local health state
- Updated `handle_slash_command` signature to accept `thread_id` for task lookup

## Implementation Details

- System commands are resolved client-side without going through the agent loop
- Channel surfaces (Slack/Telegram) get system commands via the gateway's `CommandRouter` before dispatching to agents
- Manual compaction skips threshold checks and always runs at the highest tier appropriate for current scratchpad size
- Compaction events now track whether they were triggered automatically or manually, enabling better observability and debugging
- The force compaction path ensures Tier 1 Trim runs even when usage is below the summarize threshold

https://claude.ai/code/session_011d6hggHJx24wvuQpTFVhbK