### PR TITLE
feat: read-only task streaming (useTaskStreaming / TaskView) via A2A tasks/resubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ DistriJS now includes comprehensive voice interaction capabilities:
 
 👉 **[See Voice Support Guide](VOICE_SUPPORT.md)** for complete setup instructions.
 
+## 👁️ Read-Only Task Streaming (NEW!)
+
+Follow an agent task **without owning the turn**. Where `<Chat>` / `useChat` _send_ a
+message and stream the response, `<TaskView>` / `useTaskStreaming` **attach** to a task
+that is already running (or already finished), replay its history, and follow the live
+tail — using the exact same renderers `<Chat>` uses, with **no composer** and no tool
+interaction. Under the hood this is A2A `tasks/resubscribe`.
+
+```tsx
+import { TaskView, useTaskStreaming } from '@distri/react';
+
+// 1. Turnkey read-only surface — same renderer surface as <Chat>.
+<TaskView agent={agent} taskId={taskId} rendering="rich" />
+
+// 2. Or drive your own UI from the hook.
+const { messages, isStreaming, isTerminal, reconnect } = useTaskStreaming({ agent, taskId });
+```
+
+New API:
+
+- **`@distri/core`** — `agent.resubscribe(taskId)` (decoded, read-only twin of
+  `invokeStream`) and `client.resubscribeTask(agentId, taskId)`.
+- **`@distri/react`** — `useTaskStreaming({ agent, taskId })`, `<TaskView>`, and
+  `<ChatMessageList>` (the message-list + fork-anchoring renderer shared with `<Chat>`).
+
+Three consumption levels — turnkey `<TaskView>`, `useTaskStreaming` + `<ChatMessageList>`
+in your own shell, or `useTaskStreaming` alone for a fully custom view.
+
+👉 **[See the Task Streaming guide](docs/task-streaming.md)** and the runnable
+`apps/task-stream-demo`.
+
 ## 🏗️ Architecture
 
 ```
@@ -393,6 +424,7 @@ When the agent processes a message, it will automatically include the session va
 
 - **[API Reference](./docs/api/)** - Complete API documentation
 - **[Tool System Guide](./docs/tools.md)** - In-depth tool development
+- **[Task Streaming Guide](./docs/task-streaming.md)** - Read-only task following (`useTaskStreaming` / `<TaskView>`)
 - **[Migration Guide](./docs/migration.md)** - Upgrading from previous versions
 - **[Samples](./samples/)** - Working examples and tutorials
 

--- a/apps/task-stream-demo/.env.example
+++ b/apps/task-stream-demo/.env.example
@@ -1,0 +1,3 @@
+VITE_DISTRI_BASE_URL=http://localhost:5184/v1/
+VITE_DISTRI_TOKEN=oss-anonymous
+VITE_DISTRI_AGENT_ID=coder

--- a/apps/task-stream-demo/README.md
+++ b/apps/task-stream-demo/README.md
@@ -1,0 +1,30 @@
+# Read-only task streaming demo
+
+Manual verification vehicle for `useTaskStreaming` / `<TaskView>` (see
+[`../../docs/task-streaming.md`](../../docs/task-streaming.md)).
+
+- **Left** — a `<Chat>` that sends a message. The demo captures the resulting task id.
+- **Right** — a `<TaskView>` following that same task **read-only**: it replays and
+  streams the identical transcript with no composer. You can also paste any task id to
+  follow a pre-existing task (replay + tail).
+
+## Run
+
+Point it at a running Distri server (see the repo `bin/server`), then:
+
+```bash
+# from distrijs/
+pnpm --filter @distri/react build          # TaskView lives in the built @distri/react
+pnpm --filter @distri/task-stream-demo dev  # http://localhost:5273
+```
+
+Configure via `apps/task-stream-demo/.env.local`:
+
+```
+VITE_DISTRI_BASE_URL=http://localhost:5184/v1/
+VITE_DISTRI_TOKEN=<your DISTRI_API_KEY>
+VITE_DISTRI_AGENT_ID=coder
+```
+
+Defaults target a local OSS server (`http://localhost:5184/v1/`, anonymous token,
+agent `coder`).

--- a/apps/task-stream-demo/index.html
+++ b/apps/task-stream-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Distri — read-only task streaming demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/task-stream-demo/package.json
+++ b/apps/task-stream-demo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@distri/task-stream-demo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "pnpm --filter @distri/react build",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@distri/core": "workspace:*",
+    "@distri/react": "workspace:*",
+    "react": "19.1.1",
+    "react-dom": "19.1.1",
+    "zustand": "^5.0.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.8.3",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/task-stream-demo/src/App.tsx
+++ b/apps/task-stream-demo/src/App.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from 'react';
+import {
+  DistriProvider,
+  ThemeProvider,
+  useAgent,
+  Chat,
+  TaskView,
+  type ChatState,
+} from '@distri/react';
+import { uuidv4 } from '@distri/core';
+
+/**
+ * Read-only task streaming demo.
+ *
+ * Left:  a <Chat> to SEND a message. We capture the resulting task id.
+ * Right: a <TaskView> that FOLLOWS that same task read-only — it streams the
+ *        identical transcript with no composer. You can also paste any task id
+ *        to follow a pre-existing task (replay + tail).
+ *
+ * Configure via env (`.env.local`):
+ *   VITE_DISTRI_BASE_URL   default http://localhost:5184/v1/
+ *   VITE_DISTRI_TOKEN      bearer token / DISTRI_API_KEY (default oss-anonymous)
+ *   VITE_DISTRI_AGENT_ID   default "coder"
+ */
+
+const BASE_URL = import.meta.env.VITE_DISTRI_BASE_URL ?? 'http://localhost:5184/v1/';
+const TOKEN = import.meta.env.VITE_DISTRI_TOKEN ?? 'oss-anonymous';
+const AGENT_ID = import.meta.env.VITE_DISTRI_AGENT_ID ?? 'coder';
+
+function Demo() {
+  const threadId = useMemo(() => uuidv4(), []);
+  const { agent, loading, error } = useAgent({ agentIdOrDef: AGENT_ID });
+
+  // Task id captured from the live <Chat> (root task of the current turn).
+  const [liveTaskId, setLiveTaskId] = useState<string | null>(null);
+  // Manual override: paste any task id to follow it read-only.
+  const [pastedTaskId, setPastedTaskId] = useState('');
+
+  const followedTaskId = pastedTaskId.trim() || liveTaskId;
+
+  if (loading) return <div style={{ padding: 24 }}>Loading agent “{AGENT_ID}”…</div>;
+  if (error) return <div style={{ padding: 24, color: 'crimson' }}>Failed to load agent: {String(error)}</div>;
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', gap: 1, background: 'var(--border, #333)' }}>
+      {/* LEFT: interactive chat (sends messages) */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', background: 'var(--background, #fff)' }}>
+        <Header title="① Send — <Chat>" subtitle={followedTaskId ? `following task ${followedTaskId.slice(0, 12)}…` : 'send a message to start a task'} />
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <Chat
+            agent={agent}
+            threadId={threadId}
+            enableHistory={false}
+            onChatStateChange={(state: ChatState) => {
+              if (state.currentTaskId) setLiveTaskId(state.currentTaskId);
+            }}
+          />
+        </div>
+      </div>
+
+      {/* RIGHT: read-only follower (sends nothing) */}
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', background: 'var(--background, #fff)' }}>
+        <Header title="② Follow — <TaskView>" subtitle="read-only · streams the same task · no composer" />
+        <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border, #333)' }}>
+          <input
+            value={pastedTaskId}
+            onChange={(e) => setPastedTaskId(e.target.value)}
+            placeholder="…or paste a task id to follow"
+            style={{ width: '100%', padding: 6, fontSize: 12, boxSizing: 'border-box' }}
+          />
+        </div>
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <TaskView
+            agent={agent}
+            taskId={followedTaskId}
+            threadId={threadId}
+            rendering="rich"
+            emptyState={<div style={{ padding: 24, opacity: 0.6 }}>No task followed yet. Send a message on the left, or paste a task id above.</div>}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Header({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div style={{ padding: '10px 12px', borderBottom: '1px solid var(--border, #333)' }}>
+      <div style={{ fontWeight: 600, fontSize: 14 }}>{title}</div>
+      <div style={{ fontSize: 12, opacity: 0.65 }}>{subtitle}</div>
+    </div>
+  );
+}
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <DistriProvider
+        config={{
+          baseUrl: BASE_URL,
+          accessToken: TOKEN,
+          headers: { Authorization: `Bearer ${TOKEN}` },
+        }}
+      >
+        <Demo />
+      </DistriProvider>
+    </ThemeProvider>
+  );
+}

--- a/apps/task-stream-demo/src/main.tsx
+++ b/apps/task-stream-demo/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '@distri/react/globals.css';
+import '@distri/react/theme.css';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/task-stream-demo/tsconfig.json
+++ b/apps/task-stream-demo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/task-stream-demo/vite.config.ts
+++ b/apps/task-stream-demo/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5273 },
+});

--- a/docs/superpowers/specs/2026-07-07-read-only-task-streaming-phase1-design.md
+++ b/docs/superpowers/specs/2026-07-07-read-only-task-streaming-phase1-design.md
@@ -1,0 +1,256 @@
+# Read-only task streaming — Phase 1 (React-first)
+
+**Date:** 2026-07-07
+**Status:** Approved — implement now
+**Scope:** distrijs `@distri/core` + `@distri/react`. **No server changes.**
+**Companion spec:** [`2026-07-07-read-only-task-streaming-phase2-3-core-angular-design.md`](./2026-07-07-read-only-task-streaming-phase2-3-core-angular-design.md) (core extraction + Angular — *specified, not built*)
+
+## 1. Problem
+
+Today, the only way to render an agent's activity in distrijs is `useChat` →
+`Agent.invokeStream` → `message/stream`. That couples *rendering* to *sending*: you
+must own the turn to see it. We want a **read-only** way to attach to a task that is
+already running (or already finished) and stream its updates into the exact same
+renderers `<Chat>` uses — no composer, no `sendMessage`, but the live subscription
+still works.
+
+Two triggers:
+- **Send-then-follow:** fire a message (background/foreground), then render its
+  progress in a separate read-only surface.
+- **Follow-existing:** attach to a task id (e.g. a background task) and watch it
+  replay + tail.
+
+## 2. Key enabling fact
+
+Rendering in `@distri/react` is **store-driven, not `useChat`-driven**.
+`MessageRenderer` / `SubTaskTree` / `ContextRow` render over a `ChatStore`
+(`createChatStore()`), fed by the `processMessage(event, isFromStream)` reducer
+(`stores/chatStateStore.ts`). Nothing in the render path knows whether events came
+from a live `message/stream` turn or a `tasks/resubscribe` follow. So read-only is:
+
+> same store, same reducer, same renderers — different event source, no composer.
+
+The server already implements A2A `tasks/resubscribe` (SSE): it replays the task's
+24h event log, then streams the live tail, then synthesizes a terminal frame for an
+already-finished task. `@a2a-js/sdk`'s `A2AClient` already exposes
+`resubscribeTask(params: TaskIdParams): AsyncGenerator<A2AStreamEventData>`. It is
+simply **not wrapped** in `@distri/core` yet. Phase 1 wraps it and builds the React
+surface on top.
+
+## 3. Decisions (locked)
+
+- **Scope:** task-level only. Sub-agent forks already stream under the root task, so
+  the full tree still renders. Thread-level following is a documented non-goal for v1.
+- **Transport:** wrap A2A `tasks/resubscribe` (the standard method), decoding frames
+  through the existing `decodeA2AStreamEvent`. The follower is always initialized from
+  a call site that already holds the `Agent` (you just sent with it, or resolved it via
+  `useAgent`), so the per-agent A2A URL requirement is satisfied — the hook takes an
+  `Agent`, not a bare task id.
+
+## 4. Architecture
+
+```
+@distri/core
+  DistriClient.resubscribeTask(agentId, taskId, opts) : AsyncGenerator<A2AStreamEventData>
+      └─ wraps A2AClient.resubscribeTask({ id: taskId })   (tasks/resubscribe, SSE)
+  Agent.resubscribe(taskId, opts) : AsyncGenerator<DistriChatMessage>
+      └─ decodeA2AStreamEvent per frame; NO hook/tool side-effects (read-only)
+
+@distri/react
+  useTaskStreaming({ agent, taskId, threadId?, enabled?, store? }) : UseTaskStreamingReturn
+      └─ owns createChatStore(); seed persisted history → tail via agent.resubscribe;
+         pumps processMessage(evt, true); clear-and-replay on (re)connect.
+  <ChatMessageList>            // extracted from Chat.renderMessages() — shared by both
+  <TaskView>                   // read-only surface: useTaskStreaming + ChatStoreContext
+                               //   + <ChatMessageList> + read-only <ContextRow>. No composer.
+```
+
+### 4.1 Core primitive
+
+```ts
+// DistriClient
+async *resubscribeTask(
+  agentId: string,
+  taskId: string,
+  opts?: { signal?: AbortSignal },
+): AsyncGenerator<A2AStreamEventData> {
+  const client = this.getA2AClient(agentId);
+  yield* await client.resubscribeTask({ id: taskId });
+}
+
+// Agent — read-only twin of invokeStream (decode only, no inline-hook completion)
+async *resubscribe(
+  taskId: string,
+  opts?: { signal?: AbortSignal },
+): AsyncGenerator<DistriChatMessage> {
+  for await (const event of this.client.resubscribeTask(this.agentDefinition.name, taskId, opts)) {
+    const converted = decodeA2AStreamEvent(event);
+    if (converted) yield converted;
+  }
+  // stream errors → synthesized run_error (mirror invokeStream), so read-only UIs render them in-chat
+}
+```
+
+Abort is cooperative (as in `sendMessageStream`/`useChat`): the consumer breaks out
+of the `for await` loop on `signal.aborted`, which returns the generator and closes
+the underlying fetch.
+
+### 4.2 `useTaskStreaming` hook
+
+```ts
+interface UseTaskStreamingOptions {
+  agent: Agent | null;
+  taskId: string | null;
+  threadId?: string;                 // seed persisted history (tasks older than the 24h replay window)
+  initialMessages?: DistriChatMessage[];  // pre-fetched history, like useChat
+  enabled?: boolean;                 // default true; false = do not connect
+  store?: ChatStore;                 // optional externally-owned store
+  onError?: (e: Error) => void;
+}
+interface UseTaskStreamingReturn {
+  store: ChatStore;
+  messages: DistriChatMessage[];
+  isStreaming: boolean;
+  isTerminal: boolean;
+  error: Error | null;
+  reconnect: () => void;
+  stop: () => void;
+}
+```
+
+Behavior:
+1. Owns a `createChatStore()` (or the passed store) — **identical store to live chat**.
+2. **Seed then tail:** if `initialMessages` provided, render them + `hydrateTaskTree`
+   (mirrors `useChat.ts:159-168`) so old/terminal tasks aren't blank. Then attach the tail.
+3. Open `agent.resubscribe(taskId, { signal })`; pump each event through
+   `store.getState().processMessage(evt, true)`.
+4. **Idempotent (re)connect:** `tasks/resubscribe` always replays the full log from
+   position 0. So each (re)connect first `clearAllStates()` on the store, then replays.
+   This guarantees consistent state and avoids double-appended text deltas. On an
+   unexpected close where the task is not terminal, reconnect once with a short backoff.
+5. `isTerminal` is set when a `run_finished`/`run_error` for the **subscribed** taskId
+   arrives (root terminal) — stop reconnecting.
+6. Abort on unmount / `enabled=false` / `taskId` change.
+
+### 4.3 `<ChatMessageList>` (the one intentional refactor)
+
+Extract the message-rendering loop from `Chat.tsx` — `renderMessages()`
+(`Chat.tsx:924-1007`) **plus** the trailing catch-all `<SubTaskTree excludeRootIds>`
+(`Chat.tsx:1278-1287`) and the auto-expand-running-tools effect
+(`Chat.tsx:~900-915`) — into a shared presentational component:
+
+```ts
+interface ChatMessageListProps {
+  messages: DistriChatMessage[];                 // caller supplies (Chat concatenates history)
+  toolRenderers?: ToolRendererMap;
+  rendering?: RenderingMode;
+  verbose?: boolean;
+  debug?: boolean;
+  threadId?: string;
+  enableFeedback?: boolean;
+  onShowTrace?: (threadId: string) => void;
+}
+```
+
+- Reads `tasks` / `toolCalls` from the store via `useChatStateStore` (must be inside a
+  `ChatStoreContext`). Owns `expandedTools` state + the auto-expand effect internally.
+- Renders per-turn fork anchoring (inline `SubTaskTree`) + the trailing catch-all tree,
+  exactly as Chat does today.
+- `Chat` replaces `renderMessages()` + the trailing tree with `<ChatMessageList .../>`;
+  its shell (error banner, browser preview, external tool calls, pending message,
+  footer composer) is unchanged. This dedupes the complex fork-anchoring logic instead
+  of forking a second copy for read-only.
+
+### 4.4 `<TaskView>` (read-only surface)
+
+```ts
+interface TaskViewProps {
+  agent: Agent | null;
+  taskId: string | null;
+  threadId?: string;
+  initialMessages?: DistriChatMessage[];
+  enabled?: boolean;
+  // ---- renderer customization: same surface as <Chat> ----
+  toolRenderers?: ToolRendererMap;
+  rendering?: RenderingMode;         // 'minimal' | 'rich'
+  verbose?: boolean;
+  debug?: boolean;
+  enableFeedback?: boolean;
+  onShowTrace?: (threadId: string) => void;
+  // ---- presentation ----
+  className?: string;
+  maxWidth?: string;
+  showContextRow?: boolean;          // default true; read-only ContextRow footer (todos/context, no composer)
+  emptyState?: React.ReactNode;
+  onError?: (e: Error) => void;
+  store?: ChatStore;
+}
+```
+
+`<TaskView>` = `useTaskStreaming(...)` → `<ChatStoreContext.Provider>` →
+`<ChatMessageList>` + optional read-only `<ContextRow>`. No `<ChatInput>`, no
+`sendMessage`.
+
+## 5. Renderer customization & custom views (must be documented)
+
+Three documented consumption levels — from turnkey to fully custom:
+
+1. **`<TaskView>` with renderer props** — pass `toolRenderers` (per-tool custom
+   renderers, same `ToolRendererMap` as `<Chat>`), `rendering="rich" | "minimal"`,
+   `verbose`, `enableFeedback`. Turnkey read-only transcript.
+2. **`useTaskStreaming` + `<ChatMessageList>`** — own the shell, reuse Distri's
+   renderers. Wrap `{ store }` in `<ChatStoreContext.Provider>` and drop in
+   `<ChatMessageList messages={messages} toolRenderers={...} />`. Add your own header,
+   layout, or side panels.
+3. **`useTaskStreaming` fully custom** — ignore Distri renderers entirely. Use the
+   returned `{ messages, isStreaming, isTerminal, store }` and render your own UI
+   (map `messages`, read reactive slices via `useStore(store, selector)`). This is the
+   path Angular/other frameworks conceptually mirror in Phase 3.
+
+All three are documented in `docs/task-streaming.md` with runnable snippets.
+
+## 6. Contracts & invariants
+
+- **Read-only invariant:** `useTaskStreaming` / `<TaskView>` never call `sendMessage`,
+  `completeTool`, or `completeInlineHook`. Inline-hook / external-tool events render as
+  read-only status; they never prompt for input.
+- **Event routing unchanged:** events route by `taskId`/`parentTaskId` envelope
+  (sub-agent forks land in the right `SubTaskCard`) — inherited from the shared reducer.
+- **Terminal detection:** the server closes the stream on the subscribed task's own
+  `run_finished`/`run_error` (`until_own_terminal`); hook sets `isTerminal` and stops.
+- **Stale task (>24h):** replay log expired → transcript comes from seeded history;
+  the tail is empty / immediately terminal. Graceful, not an error.
+- **`<Chat>` behavior unchanged** after the `<ChatMessageList>` extraction.
+
+## 7. Testing (red first)
+
+`@distri/core` (vitest, mocked fetch — mirror `tasks-api.test.ts`):
+- `Agent.resubscribe` decodes A2A frames into `DistriChatMessage`s (status-update →
+  event, message → message), yields in order, stops on stream close.
+- `resubscribeTask` issues `tasks/resubscribe` for `{ id: taskId }` on the agent URL.
+- stream error → synthesized `run_error`.
+
+`@distri/react` (vitest + @testing-library/react + jsdom — mirror `useBackgroundTasks.test.ts`):
+- **seed→tail:** `initialMessages` render first, then streamed events append.
+- **clear-and-replay on reconnect:** replaying the same log twice yields identical
+  `messages` (no doubled text deltas).
+- **terminal:** `run_finished` for the subscribed task sets `isTerminal`, stops reconnect.
+- **abort on unmount:** unmount aborts the generator; no post-unmount state writes.
+- `<TaskView>` renders streamed messages via `MessageRenderer` and shows no composer.
+- `<Chat>` regression: existing Chat tests still pass after `<ChatMessageList>` extraction.
+
+## 8. Manual verification vehicle
+
+`apps/task-stream-demo` — minimal Vite React app: a `<Chat>` on the left to send a
+message (captures the resulting `task.id`), a `<TaskView agent taskId>` on the right
+following the same task read-only, plus a "paste a task id" box to follow a
+pre-existing task (replay + tail). Proves the end-to-end story against a running server.
+
+## 9. Out of scope (Phase 1)
+
+- Thread-level subscription / fan-in.
+- Extracting the reducer into `@distri/core` (Phase 2).
+- Angular binding (Phase 3).
+- Adding `agent_id` to `TaskSummary` so you can follow a task discovered from a list
+  without already holding its `Agent` (noted Phase-2 nicety).
+</content>

--- a/docs/superpowers/specs/2026-07-07-read-only-task-streaming-phase2-3-core-angular-design.md
+++ b/docs/superpowers/specs/2026-07-07-read-only-task-streaming-phase2-3-core-angular-design.md
@@ -1,0 +1,176 @@
+# Read-only task streaming — Phase 2 (core extraction) + Phase 3 (Angular)
+
+**Date:** 2026-07-07
+**Status:** Specified — **do not build yet.** Build after Phase 1 ships and settles.
+**Depends on:** [`2026-07-07-read-only-task-streaming-phase1-design.md`](./2026-07-07-read-only-task-streaming-phase1-design.md)
+
+This spec covers making read-only task streaming **framework-agnostic** so it can be
+exported to Angular (and Vue/Svelte later) with zero logic duplication. It is fully
+specified here so a separate session can execute it self-contained.
+
+---
+
+## Phase 2 — Extract the reducer into `@distri/core`
+
+### Problem
+
+After Phase 1, the event→state reducer (`processMessage` + `ChatState` + the task-tree
+bookkeeping) still lives inside the React/zustand store `stores/chatStateStore.ts`. Any
+non-React framework would have to re-implement ~1600 lines of reducer logic. That is a
+correctness landmine (two divergent reducers) and violates "never reimplement existing
+functionality."
+
+### Goal
+
+Move the **pure, framework-agnostic state machine** into `@distri/core` as a
+`ChatSession` class. React's store becomes a thin adapter over it. No behavior change to
+`<Chat>` or `<TaskView>`.
+
+### Design
+
+```ts
+// @distri/core — framework-agnostic, zero React/zustand imports
+interface ChatSessionState {
+  messages: DistriChatMessage[];
+  tasks: Map<string, TaskState>;
+  toolCalls: Map<string, ToolCallState>;
+  plans: Map<string, PlanState>;
+  steps: Map<string, StepState>;
+  currentRunId?: string;
+  currentTaskId?: string;
+  todos: TodoItem[];
+  contextBudget?: ContextBudget;
+  contextBudgets: Map<string, ContextBudget>;
+  compactionEvents: CompactionLogEntry[];
+  isStreaming: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  // …the full ChatState shape, minus React.ReactNode fields (see below)
+}
+
+class ChatSession {
+  getState(): ChatSessionState;
+  applyEvent(message: DistriChatMessage, isFromStream?: boolean): void;  // == today's processMessage
+  hydrateTaskTree(links: Array<{ taskId: string; parentTaskId?: string }>): void;
+  clear(): void;
+  subscribe(listener: () => void): () => void;  // observable; fires on every state change
+  // read-only helpers: getTaskTree, getToolCallsByTaskId, hasPendingToolCalls …
+}
+```
+
+**Boundary rule — no UI in core.** Two fields on the React store are UI-coupled and
+must NOT move into `@distri/core`:
+- `ToolCallState.component?: React.ReactNode` — the rendered interactive tool element.
+- the `resumeWithToolResult` / `executeTool` machinery that *builds* React components.
+
+Resolution: `ChatSession` holds only serializable tool-call state
+(`{ tool_call_id, taskId, tool_name, input, status, result, isExternal, … }`). The React
+adapter keeps a **parallel side-map** `Map<toolCallId, React.ReactNode>` for rendered
+components and the interactive-execution logic — it layers UI concerns on top of the pure
+session, subscribing to `ChatSession` for data and augmenting with React nodes. This keeps
+core free of any framework type.
+
+### React adapter (`stores/chatStateStore.ts` becomes thin)
+
+- `createChatStore()` internally instantiates a `ChatSession`, exposes a zustand store
+  whose state mirrors `session.getState()` (updated via `session.subscribe`), and adds
+  the React-only actions (`executeTool`, `setResumeWithToolResult`, component side-map).
+- `processMessage(msg, fromStream)` delegates to `session.applyEvent(msg, fromStream)`.
+- `hydrateTaskTree`, `clearAllStates` delegate to `session.hydrateTaskTree` / `session.clear`.
+- Public React API (`useChatStateStore`, `useChatStoreApi`, `ChatStore`) is **unchanged**
+  — this is a pure internal refactor.
+
+### Migration & safety
+
+- Move the reducer logic verbatim into `ChatSession`; keep the React store's existing
+  tests (`chatStateStore-task-tree.test.ts`, `taskGrouping.test.ts`, etc.) green against
+  the adapter — they are the regression net.
+- Add core-level unit tests for `ChatSession` directly (no React): event sequences →
+  expected `getState()`, task-tree assembly, idempotent replay.
+- `useTaskStreaming` (Phase 1) needs no change — it already goes through the store; after
+  extraction it transparently rides the adapter. Optionally add a core-only
+  `TaskStreamController` (below) so non-React consumers get the subscription loop too.
+
+### Optional: `TaskStreamController` in core
+
+A framework-agnostic driver that owns a `ChatSession` + the `agent.resubscribe` loop
+(seed → tail → clear-and-replay-on-reconnect), exposing `state` via `subscribe`. React's
+`useTaskStreaming` and Angular's service both wrap this, so the *subscription lifecycle*
+(not just the reducer) is shared:
+
+```ts
+class TaskStreamController {
+  constructor(opts: { agent: Agent; taskId: string; initialMessages?: DistriChatMessage[] });
+  readonly session: ChatSession;
+  start(): void; stop(): void; reconnect(): void;
+  subscribe(listener: (s: { isStreaming: boolean; isTerminal: boolean; error: Error | null }) => void): () => void;
+}
+```
+
+### Deliverables (Phase 2)
+
+- `@distri/core`: `ChatSession`, `ChatSessionState`, (optional) `TaskStreamController` +
+  the state types (`TaskState`, `ToolCallState`, `PlanState`, `StepState`, …) moved to core.
+- `@distri/react`: `chatStateStore.ts` reduced to an adapter; all existing tests green.
+- Core unit tests for `ChatSession` and `TaskStreamController`.
+
+---
+
+## Phase 3 — Angular binding (`@distri/angular`)
+
+### Goal
+
+Ship a first-class Angular integration mirroring the React read-only surface, built
+entirely on the Phase-2 core primitives. No reducer logic in the Angular package.
+
+### Design
+
+New package `packages/angular` → `@distri/angular` (Angular 17+, standalone APIs,
+signals).
+
+```ts
+@Injectable()
+class DistriTaskStreamService {
+  // wraps core TaskStreamController + ChatSession
+  connect(opts: { agent: Agent; taskId: string; threadId?: string; initialMessages?: DistriChatMessage[] }): void;
+  disconnect(): void;
+  reconnect(): void;
+  readonly messages: Signal<DistriChatMessage[]>;
+  readonly isStreaming: Signal<boolean>;
+  readonly isTerminal: Signal<boolean>;
+  readonly error: Signal<Error | null>;
+  readonly state: Signal<ChatSessionState>;   // full session state for custom views
+}
+```
+
+- Bridge core's `subscribe(listener)` → Angular signals via `signal()` +
+  `NgZone.run` (or `toSignal` over an RxJS `Observable` adapter). Provide **both** a
+  signals API and an `Observable<ChatSessionState>` for RxJS-first apps.
+- `<distri-task-view>` standalone component: read-only transcript mirroring React's
+  `<TaskView>`. Renderer customization via `@Input() toolRenderers` (Angular
+  `TemplateRef`/component map), `rendering`, `verbose`. Message/tool rendering is
+  re-implemented in Angular templates over `ChatSessionState` — **only the view layer is
+  framework-specific; all state/subscription logic is core.**
+- Custom views: consumers inject `DistriTaskStreamService` and render `messages()` /
+  `state()` with their own templates (mirrors React consumption level 3).
+
+### Testing (Phase 3)
+
+- Angular TestBed unit tests for `DistriTaskStreamService`: mocked `Agent.resubscribe`
+  generator → signals update; reconnect clears + replays; disconnect aborts.
+- Component tests for `<distri-task-view>` rendering streamed messages, no composer.
+
+### Deliverables (Phase 3)
+
+- `packages/angular` (`@distri/angular`): `DistriTaskStreamService`,
+  `<distri-task-view>`, renderer-map support, docs.
+- An Angular demo under `apps/` (or `samples/`) mirroring the React demo.
+- `docs/task-streaming-angular.md`.
+
+### Non-goals (Phase 3)
+
+- Full interactive Angular `<Chat>` (sending, tools, composer). Only the **read-only**
+  surface is in scope — interactive parity is a later, separate effort.
+- Vue/Svelte bindings (the Phase-2 core boundary makes them straightforward follow-ups,
+  but they are not specified here).
+</content>

--- a/docs/task-streaming.md
+++ b/docs/task-streaming.md
@@ -1,0 +1,173 @@
+# Read-only task streaming
+
+Render an agent task's activity **without owning the turn**. Where `useChat` /
+`<Chat>` *send* a message and stream the response, `useTaskStreaming` / `<TaskView>`
+**attach** to a task that is already running (or already finished), replay its history,
+and follow the live tail — using the exact same renderers `<Chat>` uses, with no
+composer and no tool interaction.
+
+Under the hood this is A2A `tasks/resubscribe`: the server replays the task's event log,
+streams the live tail, then (for a finished task) sends a synthesized terminal frame.
+
+- **Core primitive:** `agent.resubscribe(taskId)` — an async generator of
+  `DistriChatMessage`s (decoded events + messages). Framework-agnostic; lives in
+  `@distri/core`.
+- **React hook:** `useTaskStreaming({ agent, taskId })` — owns a chat store, drives it
+  from `agent.resubscribe`, exposes `{ store, messages, isStreaming, isTerminal, … }`.
+- **React component:** `<TaskView agent taskId />` — turnkey read-only transcript.
+
+## The send-then-follow pattern
+
+You are always following a task you have an `Agent` for — either you just started it, or
+you resolved the agent with `useAgent`. A task id alone is not enough (A2A streams are
+per-agent).
+
+```tsx
+// 1. Fire a message (foreground or background) and capture the task id.
+const result = await agent.invoke({ message /* … */ });   // returns a Task
+const taskId = (result as { id?: string }).id;
+
+// 2. Follow it read-only — streams identically to <Chat>, but sends nothing.
+<TaskView agent={agent} taskId={taskId} threadId={threadId} />
+```
+
+You can also follow a **pre-existing** task (e.g. a background task started elsewhere):
+just pass its id.
+
+---
+
+## Three ways to consume it
+
+Pick the level that matches how much of the UI you want to own.
+
+### 1. `<TaskView>` — turnkey, with renderer customization
+
+`<TaskView>` exposes the **same renderer surface as `<Chat>`**. Pass `toolRenderers` to
+customize how specific tools render, switch density with `rendering`, and so on.
+
+```tsx
+import { TaskView } from '@distri/react';
+
+<TaskView
+  agent={agent}
+  taskId={taskId}
+  threadId={threadId}
+  initialMessages={history}          // seed persisted history (tasks older than the 24h replay window)
+  rendering="rich"                   // 'minimal' (default) | 'rich'
+  verbose
+  toolRenderers={{
+    // Same ToolRendererMap shape as <Chat>. Keyed by tool name.
+    my_custom_tool: ({ toolCall }) => <MyToolCard call={toolCall} />,
+  }}
+  onShowTrace={(threadId) => openTrace(threadId)}
+  showContextRow                     // read-only todos + context dial footer (no composer). default true
+  emptyState={<p>Waiting for activity…</p>}
+/>
+```
+
+`<TaskView>` props (renderer-related): `toolRenderers`, `rendering`, `verbose`, `debug`,
+`enableFeedback`, `onShowTrace` — identical semantics to `<Chat>`.
+
+### 2. `useTaskStreaming` + `<ChatMessageList>` — your shell, our renderers
+
+Own the layout (header, side panels, custom footer) but reuse Distri's message/tool/
+fork rendering. Wrap the returned `store` in `ChatStoreContext` and drop in
+`<ChatMessageList>`.
+
+```tsx
+import { useTaskStreaming, ChatMessageList } from '@distri/react';
+import { ChatStoreContext } from '@distri/react';
+
+function MyFollowPanel({ agent, taskId }) {
+  const { store, messages, isStreaming, isTerminal, reconnect } = useTaskStreaming({
+    agent,
+    taskId,
+  });
+
+  return (
+    <ChatStoreContext.Provider value={store}>
+      <header>
+        {isStreaming ? 'Running…' : isTerminal ? 'Done' : 'Idle'}
+        {isTerminal && <button onClick={reconnect}>Replay</button>}
+      </header>
+      <ChatMessageList
+        messages={messages}
+        rendering="rich"
+        toolRenderers={{ my_custom_tool: ({ toolCall }) => <MyToolCard call={toolCall} /> }}
+      />
+    </ChatStoreContext.Provider>
+  );
+}
+```
+
+`<ChatMessageList>` is the same message-rendering engine `<Chat>` uses — including
+per-turn fork (sub-agent) trees. It must render inside a `ChatStoreContext`.
+
+### 3. `useTaskStreaming` alone — fully custom view
+
+Ignore Distri's renderers entirely. Render `messages` however you like, and read reactive
+slices straight off the store.
+
+```tsx
+import { useTaskStreaming } from '@distri/react';
+import { useStore } from 'zustand';
+
+function RawFollow({ agent, taskId }) {
+  const { store, messages, isTerminal } = useTaskStreaming({ agent, taskId });
+  const todos = useStore(store, (s) => s.todos);          // any store slice you want
+
+  return (
+    <div>
+      <ul>{messages.map((m, i) => <li key={i}>{JSON.stringify(m)}</li>)}</ul>
+      <TodoList todos={todos} />
+      {isTerminal && <span>finished</span>}
+    </div>
+  );
+}
+```
+
+This is also the shape other frameworks mirror: the reducer and subscription loop are the
+reusable core; only the view layer is framework-specific.
+
+---
+
+## `useTaskStreaming` reference
+
+```ts
+const {
+  store,        // ChatStore backing the view (publish via ChatStoreContext, or read slices)
+  messages,     // [...initialMessages, ...live] — the display transcript
+  isStreaming,  // task is running
+  isTerminal,   // task reached its own terminal state (or the stream closed cleanly)
+  error,        // last stream error (transient errors trigger a bounded reconnect)
+  reconnect,    // force a fresh replay from the server log
+  stop,         // abort the subscription (call reconnect() to reopen)
+} = useTaskStreaming({
+  agent,            // Agent that owns the task (required to open the stream)
+  taskId,           // task to follow; null disables
+  initialMessages,  // optional pre-fetched history to seed the transcript
+  enabled,          // default true; false holds the subscription closed
+  store,            // optional externally-owned ChatStore
+  onError,          // optional error callback
+});
+```
+
+### Semantics
+
+- **Idempotent (re)connect.** `tasks/resubscribe` always replays the full log from the
+  start, so every connect first clears the store and replays. State is always consistent;
+  text deltas are never doubled on reconnect.
+- **Terminal detection.** The server closes the stream on the task's own
+  `run_finished` / `run_error`. `isTerminal` flips true and reconnection stops.
+- **Transient errors.** A dropped connection on a still-running task reconnects with a
+  short bounded backoff. After the cap, `isTerminal` is set to avoid hot-looping.
+- **Read-only invariant.** Never sends, never completes tools or inline hooks. Inline-hook
+  / external-tool events render as read-only status.
+- **Stale task (> 24h).** The replay log has expired; the transcript comes from
+  `initialMessages` and the tail is empty / immediately terminal. Not an error.
+
+## See also
+
+- Design specs: [`docs/superpowers/specs/2026-07-07-read-only-task-streaming-phase1-design.md`](./superpowers/specs/2026-07-07-read-only-task-streaming-phase1-design.md)
+- Angular + core-extraction roadmap: [`…-phase2-3-core-angular-design.md`](./superpowers/specs/2026-07-07-read-only-task-streaming-phase2-3-core-angular-design.md)
+- Demo app: `apps/task-stream-demo`

--- a/packages/core/src/__tests__/resubscribe.test.ts
+++ b/packages/core/src/__tests__/resubscribe.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Agent } from '../agent'
+import { DistriClient } from '../distri-client'
+import type { DistriChatMessage } from '../types'
+
+/**
+ * Read-only task following (Phase 1).
+ *   - Agent.resubscribe(taskId)        → decodes A2A frames into DistriChatMessages
+ *   - DistriClient.resubscribeTask(..) → wraps A2AClient.resubscribeTask (tasks/resubscribe)
+ *
+ * Agent.resubscribe is tested with an injected fake client so we exercise the
+ * decode/error path directly, without the A2AClient's agent-card fetch.
+ */
+
+function makeAgent(client: unknown): Agent {
+  const def: unknown = { name: 'test-agent' }
+  return new Agent(def as never, client as DistriClient)
+}
+
+async function collect(gen: AsyncGenerator<DistriChatMessage>): Promise<DistriChatMessage[]> {
+  const out: DistriChatMessage[] = []
+  for await (const m of gen) out.push(m)
+  return out
+}
+
+describe('Agent.resubscribe', () => {
+  it('decodes A2A frames into DistriChatMessages and yields in order', async () => {
+    const frames = [
+      { kind: 'status-update', taskId: 't1', metadata: { type: 'run_started' } },
+      { kind: 'message', messageId: 'm1', role: 'agent', parts: [{ kind: 'text', text: 'hi' }], taskId: 't1' },
+      { kind: 'status-update', taskId: 't1', metadata: { type: 'run_finished' } },
+    ]
+    const resubscribeTask = vi.fn(async function* () { for (const f of frames) yield f })
+    const agent = makeAgent({ resubscribeTask })
+
+    const result = await collect(agent.resubscribe('t1'))
+
+    expect(resubscribeTask).toHaveBeenCalledWith('test-agent', 't1', undefined)
+    expect(result.map((r) => (r as { type?: string; role?: string }).type ?? (r as { role?: string }).role))
+      .toEqual(['run_started', 'assistant', 'run_finished'])
+    expect((result[0] as { taskId?: string }).taskId).toBe('t1')
+  })
+
+  it('skips frames that decode to null', async () => {
+    const frames = [
+      { kind: 'status-update', taskId: 't1', metadata: {} }, // no type → decodes to null
+      { kind: 'status-update', taskId: 't1', metadata: { type: 'run_finished' } },
+    ]
+    const agent = makeAgent({ resubscribeTask: async function* () { for (const f of frames) yield f } })
+
+    const result = await collect(agent.resubscribe('t1'))
+
+    expect(result).toHaveLength(1)
+    expect((result[0] as { type?: string }).type).toBe('run_finished')
+  })
+
+  it('converts a mid-stream error into a run_error event', async () => {
+    const agent = makeAgent({
+      resubscribeTask: async function* () {
+        yield { kind: 'status-update', taskId: 't1', metadata: { type: 'run_started' } }
+        throw new Error('boom')
+      },
+    })
+
+    const result = await collect(agent.resubscribe('t1'))
+
+    expect((result[0] as { type?: string }).type).toBe('run_started')
+    expect((result[1] as { type?: string }).type).toBe('run_error')
+    expect((result[1] as { data?: { message?: string } }).data?.message).toBe('boom')
+  })
+})
+
+describe('DistriClient.resubscribeTask', () => {
+  it('delegates to the agent A2A client with { id } and yields raw frames', async () => {
+    const client = new DistriClient({
+      baseUrl: 'http://localhost:9999/v1',
+      headers: { Authorization: 'Bearer test-token' },
+      retryAttempts: 0,
+    })
+    const frames = [{ kind: 'status-update', taskId: 't1', metadata: { type: 'run_started' } }]
+    const a2aResubscribe = vi.fn(async function* () { for (const f of frames) yield f })
+    vi.spyOn(client as unknown as { getA2AClient: (id: string) => unknown }, 'getA2AClient')
+      .mockReturnValue({ resubscribeTask: a2aResubscribe })
+
+    const out: unknown[] = []
+    for await (const f of client.resubscribeTask('agent-x', 't1')) out.push(f)
+
+    expect((client as unknown as { getA2AClient: unknown }).getA2AClient).toHaveBeenCalledWith('agent-x')
+    expect(a2aResubscribe).toHaveBeenCalledWith({ id: 't1' })
+    expect(out).toEqual(frames)
+  })
+})

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -192,6 +192,41 @@ export class Agent {
   }
 
   /**
+   * Read-only follow of an existing task via A2A `tasks/resubscribe`.
+   *
+   * The read-only twin of {@link invokeStream}: it opens no new turn and sends
+   * nothing. It re-attaches to `taskId`, replays the server-side event log,
+   * follows the live tail, and (for an already-finished task) receives a
+   * synthesized terminal status. Each raw A2A frame is decoded via
+   * `decodeA2AStreamEvent` and yielded as a `DistriChatMessage`.
+   *
+   * Unlike `invokeStream`, this performs NO side effects — it never completes
+   * inline hooks or external tools. Following is strictly observational; the
+   * task's own owner (the live turn, elsewhere) drives it.
+   *
+   * Abort is cooperative: break out of the `for await` loop (e.g. on an
+   * `AbortSignal`) to return the generator and close the underlying stream.
+   */
+  public async *resubscribe(taskId: string, opts?: { signal?: AbortSignal }): AsyncGenerator<DistriChatMessage> {
+    const a2aStream = this.client.resubscribeTask(this.agentDefinition.name, taskId, opts);
+    try {
+      for await (const event of a2aStream) {
+        const converted = decodeA2AStreamEvent(event);
+        if (converted) yield converted;
+      }
+    } catch (error) {
+      // Mirror invokeStream: surface stream errors in-band so read-only UIs
+      // render them as a run_error instead of throwing out of the loop.
+      const message = error instanceof Error ? error.message : String(error);
+      const runError: RunErrorEvent = {
+        type: 'run_error',
+        data: { message, code: 'STREAM_ERROR' },
+      };
+      yield runError;
+    }
+  }
+
+  /**
    * Validate that required external tools are registered before invoking.
    */
   public validateExternalTools(tools: DistriBaseTool[] = []): ExternalToolValidationResult {

--- a/packages/core/src/distri-client.ts
+++ b/packages/core/src/distri-client.ts
@@ -1153,6 +1153,28 @@ export class DistriClient {
   }
 
   /**
+   * Re-attach to a task's event stream over A2A `tasks/resubscribe` (SSE).
+   *
+   * Read-only twin of {@link sendMessageStream}: instead of starting a new turn
+   * it replays the task's server-side event log, then follows the live tail,
+   * then (for an already-terminal task) receives a synthesized final status.
+   * Yields the raw A2A stream frames — decode with `decodeA2AStreamEvent`
+   * (or use {@link Agent.resubscribe}, which decodes for you).
+   *
+   * `agentId` is required because A2A clients are per-agent-URL; the caller
+   * following a task always holds the owning agent.
+   */
+  async *resubscribeTask(agentId: string, taskId: string, _opts?: { signal?: AbortSignal }): AsyncGenerator<A2AStreamEventData> {
+    try {
+      const client = this.getA2AClient(agentId);
+      yield* await client.resubscribeTask({ id: taskId });
+    } catch (error) {
+      const errorMessage = this.extractErrorMessage(error);
+      throw new DistriError(errorMessage, 'RESUBSCRIBE_TASK_ERROR', error);
+    }
+  }
+
+  /**
    * Cancel a task
    */
   async cancelTask(agentId: string, taskId: string): Promise<void> {

--- a/packages/home/src/DistriHomeClient.ts
+++ b/packages/home/src/DistriHomeClient.ts
@@ -1528,4 +1528,7 @@ export interface ModelProviderDefinition {
   keys: ProviderKeyDefinition[];
   models: Model[];
   is_custom: boolean;
+  /** Coarse grouping, e.g. "coding_plan" for subscription-backed
+   * Anthropic-compatible endpoints (Z.ai). Absent for ordinary providers. */
+  category?: string;
 }

--- a/packages/home/src/components/models/CatalogTab.tsx
+++ b/packages/home/src/components/models/CatalogTab.tsx
@@ -219,6 +219,22 @@ export function CatalogTab({
       <div className="toolbar">
         <CapChips active={capFilter} counts={counts} onChange={setCapFilter} />
         <span style={{ flex: 1 }} />
+        <div style={{ display: 'flex', gap: 4, marginRight: 8 }}>
+          <button
+            className="cap-chip"
+            title="Expand all providers"
+            onClick={() => setOpenProviders(new Set(grouped.map((g) => g.providerId)))}
+          >
+            Expand all
+          </button>
+          <button
+            className="cap-chip"
+            title="Collapse all providers"
+            onClick={() => setOpenProviders(new Set())}
+          >
+            Collapse all
+          </button>
+        </div>
         <div className="search">
           <Search size={14} />
           <input

--- a/packages/home/src/components/models/ProvidersTab.tsx
+++ b/packages/home/src/components/models/ProvidersTab.tsx
@@ -17,6 +17,8 @@ import {
   Loader2,
   Plus,
   Power,
+  Search,
+  Terminal,
   Trash2,
   X,
 } from 'lucide-react';
@@ -186,6 +188,16 @@ function ProviderRail({
   onFocus: (id: string) => void;
   onAddCustom: () => void;
 }) {
+  const [query, setQuery] = useState('');
+  const q = query.trim().toLowerCase();
+  const visible = q
+    ? providers.filter(
+        (p) =>
+          p.label.toLowerCase().includes(q) ||
+          p.id.toLowerCase().includes(q) ||
+          (p.category ?? '').toLowerCase().includes(q),
+      )
+    : providers;
   return (
     <div className="provider-list">
       <div
@@ -207,7 +219,7 @@ function ProviderRail({
             fontWeight: 600,
           }}
         >
-          {providers.length} providers
+          {q ? `${visible.length}/${providers.length}` : providers.length} providers
         </span>
         <button
           className="btn btn-secondary btn-sm"
@@ -219,7 +231,52 @@ function ProviderRail({
           <Plus size={14} />
         </button>
       </div>
-      {providers.map((p) => {
+      <div style={{ padding: '0 8px 8px' }}>
+        <div
+          className="input"
+          style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '0 8px' }}
+        >
+          <Search size={13} style={{ color: 'var(--m-text-faint)', flexShrink: 0 }} />
+          <input
+            type="text"
+            placeholder="Filter providers…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            style={{
+              flex: 1,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              color: 'var(--m-text)',
+              fontSize: 12.5,
+              padding: '6px 0',
+            }}
+          />
+          {query && (
+            <button
+              onClick={() => setQuery('')}
+              title="Clear filter"
+              aria-label="Clear filter"
+              style={{ display: 'inline-flex', color: 'var(--m-text-faint)' }}
+            >
+              <X size={13} />
+            </button>
+          )}
+        </div>
+      </div>
+      {visible.length === 0 && (
+        <div
+          style={{
+            padding: '18px 12px',
+            textAlign: 'center',
+            fontSize: 12.5,
+            color: 'var(--m-text-faint)',
+          }}
+        >
+          No providers match “{query}”.
+        </div>
+      )}
+      {visible.map((p) => {
         const conf = configured.has(p.id);
         const active = p.id === focusId;
         const defaultCaps = defaultsByProvider.get(p.id);
@@ -238,9 +295,17 @@ function ProviderRail({
                 style={{ display: 'flex', alignItems: 'center', gap: 6 }}
               >
                 <span>{p.label}</span>
+                {p.category === 'coding_plan' && (
+                  <span
+                    title="Coding plan — reuse a Claude Code / z.ai subscription (Anthropic-compatible API)"
+                    style={{ display: 'inline-flex', color: '#a855f7', flexShrink: 0 }}
+                  >
+                    <Terminal size={13} />
+                  </span>
+                )}
                 {defaultCaps && defaultCaps.length > 0 && (
                   <span
-                    title={`Default for ${defaultCaps.map((c) => CAPABILITY_META[c].short).join(', ')}`}
+                    title={`Workspace default for ${defaultCaps.map((c) => CAPABILITY_META[c].short).join(', ')}`}
                     style={{
                       fontSize: 9.5,
                       letterSpacing: '0.08em',
@@ -253,7 +318,7 @@ function ProviderRail({
                       padding: '1px 5px',
                     }}
                   >
-                    Default
+                    Default · {defaultCaps.map((c) => CAPABILITY_META[c].short).join(' · ')}
                   </span>
                 )}
               </div>
@@ -364,6 +429,21 @@ function ProviderPanel({
         <div>
           <h2 style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
             <span>{provider.label}</span>
+            {provider.category === 'coding_plan' && (
+              <span
+                title="Coding plan — reuse a Claude Code / z.ai subscription (Anthropic-compatible API)"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: '#c084fc',
+                }}
+              >
+                <Terminal size={14} /> Coding Plan
+              </span>
+            )}
             {defaultCapabilities.length > 0 && (
               <span
                 title={`Workspace default for ${defaultCapabilities.map((c) => CAPABILITY_META[c].short).join(', ')}`}

--- a/packages/react/src/__tests__/TaskView.test.tsx
+++ b/packages/react/src/__tests__/TaskView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import type { Agent, DistriChatMessage } from '@distri/core'
+import { TaskView } from '../components/TaskView'
+
+/**
+ * The read-only surface renders streamed messages with the standard renderers
+ * and never shows a composer.
+ */
+
+const TASK = 't1'
+
+const evt = (type: string, data: Record<string, unknown> = {}): DistriChatMessage =>
+  ({ type, taskId: TASK, data } as unknown as DistriChatMessage)
+
+function textStream(text: string): DistriChatMessage[] {
+  return [
+    evt('run_started', { taskId: TASK }),
+    evt('text_message_start', { message_id: 'm1', role: 'assistant' }),
+    evt('text_message_content', { message_id: 'm1', delta: text }),
+    evt('text_message_end', { message_id: 'm1' }),
+    evt('run_finished', { taskId: TASK }),
+  ]
+}
+
+function makeAgent(log: DistriChatMessage[]): Agent {
+  const resubscribe = vi.fn(async function* (_taskId: string) {
+    for (const e of log) yield e
+  })
+  return { resubscribe } as unknown as Agent
+}
+
+afterEach(() => cleanup())
+
+describe('<TaskView>', () => {
+  it('streams the followed task into the transcript', async () => {
+    const agent = makeAgent(textStream('read-only streamed answer'))
+
+    render(<TaskView agent={agent} taskId={TASK} />)
+
+    await waitFor(() => expect(screen.getByText(/read-only streamed answer/)).toBeInTheDocument())
+  })
+
+  it('renders no composer / text input (read-only)', async () => {
+    const agent = makeAgent(textStream('no composer here'))
+
+    const { container } = render(<TaskView agent={agent} taskId={TASK} />)
+
+    await waitFor(() => expect(screen.getByText(/no composer here/)).toBeInTheDocument())
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(container.querySelector('input[type="text"]')).toBeNull()
+  })
+
+  it('renders the empty state when there is nothing to show and disabled', () => {
+    const agent = makeAgent([])
+    render(
+      <TaskView agent={agent} taskId={null} enabled={false} emptyState={<div>nothing yet</div>} />,
+    )
+    expect(screen.getByText('nothing yet')).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/__tests__/chat-forwards-send-options.test.tsx
+++ b/packages/react/src/__tests__/chat-forwards-send-options.test.tsx
@@ -26,6 +26,19 @@ beforeAll(() => {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 async function* emptyStream(): AsyncGenerator<never> {}
 
+// Minimal DistriContext client covering the methods ChatInner's effects call
+// on mount (thread details + background-task hydration). Without these the
+// effects throw, and under React 19.2's stricter passive-effect error handling
+// that fails the render.
+function makeMockDistriClient() {
+  return {
+    getThread: vi.fn(async () => null),
+    listTasks: vi.fn(async () => []),
+    getTaskById: vi.fn(async () => null),
+    cancelTask: vi.fn(async () => {}),
+  } as never
+}
+
 function makeMockAgent(invokeStream: ReturnType<typeof vi.fn>) {
   return {
     name: 'zippy_browser',
@@ -47,7 +60,7 @@ describe('Chat — forwards per-send options.metadata to agent.invokeStream', ()
     let instance: ChatInstance | undefined
 
     render(
-      <DistriContext.Provider value={{ client: {} as never }}>
+      <DistriContext.Provider value={{ client: makeMockDistriClient() }}>
         <ChatInner
           agent={agent as never}
           threadId="t-1"
@@ -79,7 +92,7 @@ describe('Chat — forwards per-send options.metadata to agent.invokeStream', ()
     let instance: ChatInstance | undefined
 
     render(
-      <DistriContext.Provider value={{ client: {} as never }}>
+      <DistriContext.Provider value={{ client: makeMockDistriClient() }}>
         <ChatInner
           agent={agent as never}
           threadId="t-2"

--- a/packages/react/src/__tests__/useTaskStreaming.test.ts
+++ b/packages/react/src/__tests__/useTaskStreaming.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, waitFor, cleanup, act } from '@testing-library/react'
+import type { Agent, DistriChatMessage, DistriMessage } from '@distri/core'
+import { useTaskStreaming } from '../useTaskStreaming'
+import { createChatStore, type ChatStore } from '../stores/chatStateStore'
+
+/**
+ * Read-only task following hook (Phase 1). A fake Agent supplies the
+ * `resubscribe` async generator; we drive it and assert against the store.
+ */
+
+const TASK = 't1'
+
+function assistantMsg(id: string, text: string): DistriChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [{ part_type: 'text', data: text }],
+    created_at: 1,
+    taskId: TASK,
+  } as unknown as DistriChatMessage
+}
+
+function userMsg(id: string, text: string): DistriChatMessage {
+  return {
+    id,
+    role: 'user',
+    parts: [{ part_type: 'text', data: text }],
+    created_at: 0,
+    taskId: TASK,
+  } as unknown as DistriChatMessage
+}
+
+const evt = (type: string, data: Record<string, unknown> = {}): DistriChatMessage =>
+  ({ type, taskId: TASK, data } as unknown as DistriChatMessage)
+
+// A four-event text stream that renders as a single assistant message "hello".
+const textStreamLog = (): DistriChatMessage[] => [
+  evt('text_message_start', { message_id: 'm1', role: 'assistant' }),
+  evt('text_message_content', { message_id: 'm1', delta: 'hel' }),
+  evt('text_message_content', { message_id: 'm1', delta: 'lo' }),
+  evt('text_message_end', { message_id: 'm1' }),
+  evt('run_finished', { taskId: TASK }),
+]
+
+function makeAgent(logFactory: () => DistriChatMessage[]) {
+  const resubscribe = vi.fn(async function* (_taskId: string) {
+    for (const e of logFactory()) yield e
+  })
+  return { resubscribe } as unknown as Agent
+}
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+function assistantText(messages: DistriChatMessage[]): string[] {
+  return messages
+    .filter((m) => (m as DistriMessage).role === 'assistant')
+    .map((m) => ((m as DistriMessage).parts.find((p) => p.part_type === 'text') as { data?: string } | undefined)?.data ?? '')
+}
+
+afterEach(() => cleanup())
+
+describe('useTaskStreaming', () => {
+  it('seeds persisted history then appends the streamed tail', async () => {
+    const agent = makeAgent(() => [assistantMsg('a1', 'streamed reply'), evt('run_finished', { taskId: TASK })])
+    const initialMessages = [userMsg('u1', 'the original question')]
+
+    const { result } = renderHook(() =>
+      useTaskStreaming({ agent, taskId: TASK, initialMessages }),
+    )
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true))
+
+    // History first, streamed tail after.
+    expect(result.current.messages[0]).toMatchObject({ id: 'u1', role: 'user' })
+    expect(assistantText(result.current.messages)).toContain('streamed reply')
+  })
+
+  it('sets isTerminal when the followed task finishes', async () => {
+    const agent = makeAgent(() => [evt('run_started', { taskId: TASK }), evt('run_finished', { taskId: TASK })])
+
+    const { result } = renderHook(() => useTaskStreaming({ agent, taskId: TASK }))
+
+    await waitFor(() => expect(result.current.isTerminal).toBe(true))
+    expect(result.current.isStreaming).toBe(false)
+  })
+
+  it('clears and replays on reconnect — text deltas are not doubled', async () => {
+    const agent = makeAgent(textStreamLog)
+    const store: ChatStore = createChatStore()
+
+    const { result } = renderHook(() => useTaskStreaming({ agent, taskId: TASK, store }))
+    await waitFor(() => expect(result.current.isTerminal).toBe(true))
+    expect(assistantText(store.getState().messages)).toEqual(['hello'])
+
+    act(() => result.current.reconnect())
+
+    await waitFor(() => expect((agent.resubscribe as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2))
+    await waitFor(() => expect(result.current.isTerminal).toBe(true))
+
+    // Exactly one assistant message, text still "hello" (not "hellohello").
+    expect(assistantText(store.getState().messages)).toEqual(['hello'])
+  })
+
+  it('stops processing events after unmount (cooperative abort)', async () => {
+    const gate = deferred()
+    const resubscribe = vi.fn(async function* (_taskId: string) {
+      yield evt('run_started', { taskId: TASK })
+      await gate.promise
+      yield assistantMsg('late', 'should be ignored')
+    })
+    const agent = { resubscribe } as unknown as Agent
+    const store: ChatStore = createChatStore()
+
+    const { unmount } = renderHook(() => useTaskStreaming({ agent, taskId: TASK, store }))
+
+    await waitFor(() => expect(store.getState().currentTaskId).toBe(TASK))
+
+    unmount()
+    // Release the blocked generator only after unmount; the loop must break
+    // on the aborted signal before processing the late event.
+    await act(async () => { gate.resolve(); await Promise.resolve() })
+
+    expect(assistantText(store.getState().messages)).not.toContain('should be ignored')
+  })
+
+  it('does not connect when disabled or taskId is null', async () => {
+    const agent = makeAgent(() => [evt('run_finished', { taskId: TASK })])
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useTaskStreaming({ agent, taskId: TASK, enabled }),
+      { initialProps: { enabled: false } },
+    )
+    await Promise.resolve()
+    expect(agent.resubscribe as ReturnType<typeof vi.fn>).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(agent.resubscribe as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/react/src/components/Chat.tsx
+++ b/packages/react/src/components/Chat.tsx
@@ -2,9 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useImperativeHandle, f
 import { Agent, DistriChatMessage, DistriMessage, DistriPart, DistriThread, ToolCall, ToolExecutionOptions, DistriClient, convertDistriMessageToA2A } from '@distri/core';
 import { ChatInput, AttachedImage } from './ChatInput';
 import { useChat, type SendMessageOptions } from '../useChat';
-import { MessageRenderer } from './renderers/MessageRenderer';
-import { SubTaskTree } from './renderers/SubTaskTree';
-import { childTaskIdSet, isChildTaskMessage } from './renderers/taskGrouping';
+import { ChatMessageList } from './ChatMessageList';
 import { useBackgroundTasks } from '../useBackgroundTasks';
 import { ContextRow } from './ContextRow';
 import { MessageReadProvider } from './renderers/MessageReadContext';
@@ -246,7 +244,6 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
 
   const [input, setInput] = useState(initialInput ?? '');
   const initialInputRef = useRef(initialInput ?? '');
-  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const diagnoseThreadIdsRef = useRef<Map<string, string>>(new Map());
   const diagnoseAgentRef = useRef<Agent | null>(null);
@@ -878,133 +875,10 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
     return () => unsub();
   }, [onTaskFinish]);
 
-  const toggleToolExpansion = useCallback((toolId: string) => {
-    setExpandedTools(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(toolId)) {
-        newSet.delete(toolId);
-      } else {
-        newSet.add(toolId);
-      }
-      return newSet;
-    });
-  }, []);
-
   // Auto-scroll to bottom
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
-
-  // Auto-expand tools that are running or have errors
-  useEffect(() => {
-    const newExpanded = new Set(expandedTools);
-    let hasChanges = false;
-
-    toolCalls.forEach(toolCall => {
-      if (toolCall.status === 'running' || toolCall.status === 'error' || toolCall.status === 'user_action_required') {
-        if (!newExpanded.has(toolCall.tool_call_id)) {
-          newExpanded.add(toolCall.tool_call_id);
-          hasChanges = true;
-        }
-      }
-    });
-
-    if (hasChanges) {
-      setExpandedTools(newExpanded);
-    }
-  }, [toolCalls, expandedTools]);
-
-
-
-  // Roots whose fork-trees were anchored inline this render (consumed by the
-  // trailing catch-all tree so nothing renders twice).
-  const anchoredRootsRef = useRef<Set<string>>(new Set());
-
-  // Render messages using the new MessageRenderer
-  const renderMessages = (): React.ReactNode[] => {
-    const elements: React.ReactNode[] = [];
-
-    // Child-task messages (forked sub-agents) render inside their SubTaskCard,
-    // not in the flat column — otherwise every fork's relayed activity
-    // interleaves with the parent's own and the run reads as one giant thread.
-    const tasksSnapshot = chatStore.getState().tasks;
-    const childIds = childTaskIdSet(tasksSnapshot);
-
-    // Anchor each turn's fork cards right AFTER that turn's last message —
-    // one global tree at the bottom mixed every turn's forks into a single
-    // pile detached from the conversation.
-    const rootsWithChildren = Array.from(tasksSnapshot.values()).filter(
-      (t) => !t.parentTaskId && t.childTaskIds.length > 0,
-    );
-    const lastIndexByRoot = new Map<string, number>();
-    messages.forEach((m: any, i: number) => {
-      const tid = (m as { taskId?: string }).taskId;
-      if (tid && rootsWithChildren.some((r) => r.id === tid)) lastIndexByRoot.set(tid, i);
-    });
-    const treesAtIndex = new Map<number, string[]>();
-    const anchoredRoots = new Set<string>();
-    for (const r of rootsWithChildren) {
-      const idx = lastIndexByRoot.get(r.id);
-      if (idx !== undefined) {
-        treesAtIndex.set(idx, [...(treesAtIndex.get(idx) ?? []), r.id]);
-        anchoredRoots.add(r.id);
-      }
-    }
-    anchoredRootsRef.current = anchoredRoots;
-
-    // Render all messages using MessageRenderer
-    messages.forEach((message: any, index: number) => {
-      if (isChildTaskMessage(message, childIds)) {
-        maybeAppendTrees(index);
-        return;
-      }
-      const renderedMessage = (
-        <MessageRenderer
-          key={`message-${index}`}
-          message={message}
-          index={index}
-          toolRenderers={mergedToolRenderers}
-          isExpanded={expandedTools.has(message.id || `message-${index}`)}
-          onToggle={() => {
-            const messageId = message.id || `message-${index}`;
-            toggleToolExpansion(messageId);
-          }}
-          debug={tracesEnabled}
-          verbose={verbose}
-          rendering={rendering}
-          threadId={threadId}
-          enableFeedback={enableFeedback}
-          onShowTrace={traceOpener}
-        />
-      );
-
-      // Only add non-null rendered messages
-      if (renderedMessage !== null) {
-        elements.push(renderedMessage);
-      }
-      maybeAppendTrees(index);
-    });
-
-    return elements;
-
-    function maybeAppendTrees(index: number) {
-      for (const rootId of treesAtIndex.get(index) ?? []) {
-        elements.push(
-          <SubTaskTree
-            key={`tree-${rootId}`}
-            rootTaskId={rootId}
-            messages={messages}
-            toolRenderers={mergedToolRenderers}
-            rendering={rendering}
-            threadId={threadId}
-            onShowTrace={traceOpener}
-            verbose={verbose}
-            debug={tracesEnabled}
-          />,
-        );
-      }
-    }
-  };
 
   const renderExternalToolCalls = () => {
     const elements: React.ReactNode[] = [];
@@ -1272,18 +1146,16 @@ export const ChatInner = forwardRef<ChatInstance, ChatProps>(function ChatInner(
             <MessageReadProvider threadId={threadId} enabled={enableFeedback}>
               <div className="flex-1 min-w-0 space-y-4 w-full">
                 {emptyStateContent}
-                {/* Render all messages and state */}
-                {renderMessages()}
-
-                <SubTaskTree
-                  excludeRootIds={anchoredRootsRef.current}
+                {/* Render all messages and state (shared with read-only <TaskView>) */}
+                <ChatMessageList
                   messages={messages}
                   toolRenderers={mergedToolRenderers}
                   rendering={rendering}
-                  threadId={threadId}
-                  onShowTrace={traceOpener}
                   verbose={verbose}
                   debug={tracesEnabled}
+                  threadId={threadId}
+                  enableFeedback={enableFeedback}
+                  onShowTrace={traceOpener}
                 />
 
                 {renderExternalToolCalls()}

--- a/packages/react/src/components/ChatMessageList.tsx
+++ b/packages/react/src/components/ChatMessageList.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { DistriChatMessage } from '@distri/core';
+import { MessageRenderer } from './renderers/MessageRenderer';
+import { SubTaskTree } from './renderers/SubTaskTree';
+import { childTaskIdSet, isChildTaskMessage } from './renderers/taskGrouping';
+import { useChatStateStore, useChatStoreApi } from '../stores/chatStateStore';
+import { ToolRendererMap, RenderingMode } from '@/types';
+
+export interface ChatMessageListProps {
+  /**
+   * Messages to render. The caller supplies this (rather than reading it from
+   * the store) because `<Chat>` concatenates persisted history in front of the
+   * live store messages. Child-task (forked sub-agent) messages are grouped
+   * into their `SubTaskCard` automatically — do not pre-filter them out.
+   */
+  messages: DistriChatMessage[];
+  toolRenderers?: ToolRendererMap;
+  rendering?: RenderingMode;
+  verbose?: boolean;
+  debug?: boolean;
+  threadId?: string;
+  enableFeedback?: boolean;
+  onShowTrace?: (threadId: string) => void;
+}
+
+/**
+ * Renders a Distri message transcript: the flat message column with per-turn
+ * fork trees anchored inline and a trailing catch-all tree for any un-anchored
+ * roots. Reads task/tool state from the nearest `ChatStoreContext`, so it must
+ * render inside a `<Chat>` / `useChat` / `useTaskStreaming` subtree.
+ *
+ * Extracted from `<Chat>` so the interactive chat and the read-only
+ * `<TaskView>` share one implementation of the (non-trivial) fork-anchoring
+ * logic instead of maintaining two copies.
+ */
+export const ChatMessageList: React.FC<ChatMessageListProps> = ({
+  messages,
+  toolRenderers,
+  rendering = 'minimal',
+  verbose = false,
+  debug = false,
+  threadId,
+  enableFeedback = false,
+  onShowTrace,
+}) => {
+  const store = useChatStoreApi();
+  const toolCalls = useChatStateStore((s) => s.toolCalls);
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+
+  const toggleToolExpansion = useCallback((toolId: string) => {
+    setExpandedTools((prev) => {
+      const next = new Set(prev);
+      if (next.has(toolId)) next.delete(toolId);
+      else next.add(toolId);
+      return next;
+    });
+  }, []);
+
+  // Auto-expand tools that are running, errored, or awaiting user action.
+  useEffect(() => {
+    const next = new Set(expandedTools);
+    let changed = false;
+    toolCalls.forEach((toolCall) => {
+      if (toolCall.status === 'running' || toolCall.status === 'error' || toolCall.status === 'user_action_required') {
+        if (!next.has(toolCall.tool_call_id)) {
+          next.add(toolCall.tool_call_id);
+          changed = true;
+        }
+      }
+    });
+    if (changed) setExpandedTools(next);
+  }, [toolCalls, expandedTools]);
+
+  const elements: React.ReactNode[] = [];
+
+  // Child-task messages (forked sub-agents) render inside their SubTaskCard, not
+  // in the flat column — otherwise every fork's relayed activity interleaves
+  // with the parent's own and the run reads as one giant thread.
+  const tasksSnapshot = store.getState().tasks;
+  const childIds = childTaskIdSet(tasksSnapshot);
+
+  // Anchor each turn's fork cards right AFTER that turn's last message — one
+  // global tree at the bottom mixed every turn's forks into a single pile
+  // detached from the conversation.
+  const rootsWithChildren = Array.from(tasksSnapshot.values()).filter(
+    (t) => !t.parentTaskId && t.childTaskIds.length > 0,
+  );
+  const lastIndexByRoot = new Map<string, number>();
+  messages.forEach((m, i) => {
+    const tid = (m as { taskId?: string }).taskId;
+    if (tid && rootsWithChildren.some((r) => r.id === tid)) lastIndexByRoot.set(tid, i);
+  });
+  const treesAtIndex = new Map<number, string[]>();
+  const anchoredRoots = new Set<string>();
+  for (const r of rootsWithChildren) {
+    const idx = lastIndexByRoot.get(r.id);
+    if (idx !== undefined) {
+      treesAtIndex.set(idx, [...(treesAtIndex.get(idx) ?? []), r.id]);
+      anchoredRoots.add(r.id);
+    }
+  }
+
+  const appendTrees = (index: number) => {
+    for (const rootId of treesAtIndex.get(index) ?? []) {
+      elements.push(
+        <SubTaskTree
+          key={`tree-${rootId}`}
+          rootTaskId={rootId}
+          messages={messages}
+          toolRenderers={toolRenderers}
+          rendering={rendering}
+          threadId={threadId}
+          onShowTrace={onShowTrace}
+          verbose={verbose}
+          debug={debug}
+        />,
+      );
+    }
+  };
+
+  messages.forEach((message, index) => {
+    if (isChildTaskMessage(message, childIds)) {
+      appendTrees(index);
+      return;
+    }
+    const rendered = (
+      <MessageRenderer
+        key={`message-${index}`}
+        message={message}
+        index={index}
+        toolRenderers={toolRenderers}
+        isExpanded={expandedTools.has((message as { id?: string }).id || `message-${index}`)}
+        onToggle={() => toggleToolExpansion((message as { id?: string }).id || `message-${index}`)}
+        debug={debug}
+        verbose={verbose}
+        rendering={rendering}
+        threadId={threadId}
+        enableFeedback={enableFeedback}
+        onShowTrace={onShowTrace}
+      />
+    );
+    if (rendered !== null) elements.push(rendered);
+    appendTrees(index);
+  });
+
+  return (
+    <>
+      {elements}
+      {/* Catch-all for roots that never got anchored inline (no message carried
+          their taskId this render). */}
+      <SubTaskTree
+        excludeRootIds={anchoredRoots}
+        messages={messages}
+        toolRenderers={toolRenderers}
+        rendering={rendering}
+        threadId={threadId}
+        onShowTrace={onShowTrace}
+        verbose={verbose}
+        debug={debug}
+      />
+    </>
+  );
+};

--- a/packages/react/src/components/TaskView.tsx
+++ b/packages/react/src/components/TaskView.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Agent, DistriChatMessage } from '@distri/core';
+import { ChatStore, ChatStoreContext, useChatStateStore } from '../stores/chatStateStore';
+import { useTaskStreaming } from '../useTaskStreaming';
+import { ChatMessageList } from './ChatMessageList';
+import { ContextRow } from './ContextRow';
+import { ToolRendererMap, RenderingMode } from '@/types';
+
+export interface TaskViewProps {
+  /** The agent that owns the task (needed to open the resubscribe stream). */
+  agent: Agent | null;
+  /** The task to follow read-only. `null` renders empty. */
+  taskId: string | null;
+  /** Thread history to seed the transcript (tasks older than the 24h replay window). */
+  initialMessages?: DistriChatMessage[];
+  /** Hold the subscription closed when `false`. Default `true`. */
+  enabled?: boolean;
+
+  // ---- Renderer customization: the same surface as <Chat> ----
+  /** Per-tool custom renderers, keyed by tool name. Same `ToolRendererMap` as `<Chat>`. */
+  toolRenderers?: ToolRendererMap;
+  /** `'minimal'` (compact rows) or `'rich'` (expanded cards). Default `'minimal'`. */
+  rendering?: RenderingMode;
+  verbose?: boolean;
+  debug?: boolean;
+  enableFeedback?: boolean;
+  onShowTrace?: (threadId: string) => void;
+
+  // ---- Presentation ----
+  threadId?: string;
+  className?: string;
+  maxWidth?: string;
+  /** Show the read-only status footer (todos + context dial, no composer). Default `true`. */
+  showContextRow?: boolean;
+  /** Rendered when there are no messages and nothing is streaming. */
+  emptyState?: React.ReactNode;
+  onError?: (error: Error) => void;
+  /** Optional externally-owned store (advanced). */
+  store?: ChatStore;
+}
+
+/**
+ * Read-only view of a task's activity. Sends nothing — it attaches to `taskId`
+ * via A2A `tasks/resubscribe`, replays the server-side event log, follows the
+ * live tail, and renders with the exact same renderers `<Chat>` uses (no
+ * composer, no tool interaction).
+ *
+ * Three ways to consume read-only task streaming, from turnkey to fully custom:
+ *  1. `<TaskView>` with renderer props (this component).
+ *  2. `useTaskStreaming` + `<ChatMessageList>` inside your own shell.
+ *  3. `useTaskStreaming` alone → render `messages` / `store` however you like.
+ */
+export const TaskView: React.FC<TaskViewProps> = ({
+  agent,
+  taskId,
+  initialMessages,
+  enabled = true,
+  toolRenderers,
+  rendering = 'minimal',
+  verbose = false,
+  debug = false,
+  enableFeedback = false,
+  onShowTrace,
+  threadId,
+  className = '',
+  maxWidth,
+  showContextRow = true,
+  emptyState,
+  onError,
+  store: providedStore,
+}) => {
+  const { store, messages, isStreaming } = useTaskStreaming({
+    agent,
+    taskId,
+    initialMessages,
+    enabled,
+    store: providedStore,
+    onError,
+  });
+
+  const hasContent = messages.length > 0 || isStreaming;
+
+  return (
+    <ChatStoreContext.Provider value={store}>
+      <div
+        className={`flex flex-col h-full bg-background text-foreground font-sans overflow-hidden ${className}`}
+        style={{ maxWidth }}
+      >
+        <div className="flex-1 overflow-y-auto">
+          <div
+            className="mx-auto w-full px-2 py-4 text-sm space-y-4"
+            style={{ maxWidth: maxWidth || '768px', width: '100%', boxSizing: 'border-box' }}
+          >
+            {!hasContent && emptyState}
+            <ChatMessageList
+              messages={messages}
+              toolRenderers={toolRenderers}
+              rendering={rendering}
+              verbose={verbose}
+              debug={debug}
+              threadId={threadId}
+              enableFeedback={enableFeedback}
+              onShowTrace={onShowTrace}
+            />
+          </div>
+        </div>
+        {showContextRow && (
+          <footer className="sticky bottom-0 inset-x-0 z-30 border-t border-border bg-background/80 backdrop-blur">
+            <div className="mx-auto w-full px-4 py-3" style={{ maxWidth: maxWidth || '768px' }}>
+              <ReadOnlyContextRow />
+            </div>
+          </footer>
+        )}
+      </div>
+    </ChatStoreContext.Provider>
+  );
+};
+
+/**
+ * Read-only `<ContextRow>` bound to the nearest task-stream store. Shows the
+ * thinking indicator, todos chip, and context dial — no composer, no actions.
+ * Renders nothing when there is nothing to show.
+ */
+const ReadOnlyContextRow: React.FC = () => {
+  const todos = useChatStateStore((s) => s.todos);
+  const todoChanges = useChatStateStore((s) => s.lastTodoChanges);
+  const isStreaming = useChatStateStore((s) => s.isStreaming);
+  const contextBudget = useChatStateStore((s) => s.contextBudget);
+  const compactions = useChatStateStore((s) => s.compactionEvents);
+  return (
+    <ContextRow
+      todos={todos}
+      todoChanges={todoChanges}
+      isStreaming={isStreaming}
+      contextBudget={contextBudget ?? undefined}
+      compactions={compactions}
+    />
+  );
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 // Core exports
 export * from './useChat';
+export * from './useTaskStreaming';
 export * from './useAgent';
 export * from './useAgentDefinitions';
 export * from './useThreads';
@@ -8,6 +9,8 @@ export * from './useBackgroundTasks';
 
 // Component exports
 export * from './components/Chat';
+export * from './components/ChatMessageList';
+export * from './components/TaskView';
 export * from './components/AgentList';
 export * from './components/AgentSelect';
 export * from './components/ChatInput';

--- a/packages/react/src/useTaskStreaming.ts
+++ b/packages/react/src/useTaskStreaming.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useStore } from 'zustand';
+import { Agent, DistriChatMessage } from '@distri/core';
+import { ChatStore, createChatStore } from './stores/chatStateStore';
+
+export interface UseTaskStreamingOptions {
+  /**
+   * The agent that owns the task. Required to open the A2A `tasks/resubscribe`
+   * stream (A2A clients are per-agent-URL). A read-only follower is always
+   * initialized from a call site that already holds the agent — you just sent
+   * with it, or resolved it via `useAgent`.
+   */
+  agent: Agent | null;
+  /** The task to follow. `null` disables the subscription. */
+  taskId: string | null;
+  /**
+   * The thread's persisted history, pre-fetched by the caller (e.g. via
+   * `useChatMessages`). Render-only: it is concatenated in front of the live
+   * store messages and used to rebuild the fork task-tree, so tasks older than
+   * the server's 24h replay window still render. Never pumped into the store.
+   */
+  initialMessages?: DistriChatMessage[];
+  /** Set `false` to hold the subscription closed. Default `true`. */
+  enabled?: boolean;
+  /**
+   * Optional externally-owned store. When omitted, this hook creates and owns
+   * a per-instance store (fresh, empty state per mount).
+   */
+  store?: ChatStore;
+  onError?: (error: Error) => void;
+}
+
+export interface UseTaskStreamingReturn {
+  /** The chat-state store backing this hook. Publish via `ChatStoreContext` to
+   *  render with Distri renderers, or read reactive slices for a custom view. */
+  store: ChatStore;
+  messages: DistriChatMessage[];
+  /** True while the followed task is running (mirrors the store's streaming flag). */
+  isStreaming: boolean;
+  /** True once the followed task reached its own terminal state (or the stream
+   *  closed cleanly). Reconnection stops once terminal. */
+  isTerminal: boolean;
+  error: Error | null;
+  /** Force a fresh (re)connect: wipes and replays from the server log. */
+  reconnect: () => void;
+  /** Abort the subscription. Call `reconnect()` to reopen it. */
+  stop: () => void;
+}
+
+const MAX_RECONNECTS = 3;
+
+function hydrateFromHistory(store: ChatStore, initialMessages?: DistriChatMessage[]): void {
+  if (!initialMessages || initialMessages.length === 0) return;
+  const links = initialMessages
+    .map((m) => ({
+      taskId: (m as { taskId?: string }).taskId as string,
+      parentTaskId: (m as { parentTaskId?: string }).parentTaskId,
+    }))
+    .filter((l) => Boolean(l.taskId));
+  if (links.length > 0) store.getState().hydrateTaskTree(links);
+}
+
+/**
+ * Read-only follow of an existing task. The observational twin of `useChat`:
+ * it owns a chat-state store and drives it from `agent.resubscribe(taskId)`
+ * (A2A `tasks/resubscribe`) instead of from a `sendMessage` turn. Renders with
+ * the exact same store the interactive chat uses — attach `<ChatMessageList>`
+ * (via `<ChatStoreContext.Provider value={store}>`) or build a custom view from
+ * the returned `messages` / `store`.
+ *
+ * (Re)connect is idempotent: `tasks/resubscribe` always replays the full event
+ * log from position 0, so every connect first clears the store and replays —
+ * guaranteeing consistent state with no doubled text deltas.
+ */
+export function useTaskStreaming({
+  agent,
+  taskId,
+  initialMessages,
+  enabled = true,
+  store: providedStore,
+  onError,
+}: UseTaskStreamingOptions): UseTaskStreamingReturn {
+  const [fallbackStore] = useState<ChatStore>(() => createChatStore());
+  const store = providedStore ?? fallbackStore;
+
+  const messages = useStore(store, (s) => s.messages);
+  const isStreaming = useStore(store, (s) => s.isStreaming);
+  const [isTerminal, setIsTerminal] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [reconnectKey, setReconnectKey] = useState(0);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const onErrorRef = useRef(onError);
+  useEffect(() => { onErrorRef.current = onError; }, [onError]);
+
+  // Seed the fork task-tree from history for the not-yet-connected display
+  // (the connect loop re-hydrates after each clear).
+  useEffect(() => {
+    hydrateFromHistory(store, initialMessages);
+  }, [initialMessages, store]);
+
+  useEffect(() => {
+    if (!enabled || !agent || !taskId) return;
+
+    const ac = new AbortController();
+    abortRef.current = ac;
+    let cancelled = false;
+    setIsTerminal(false);
+    setError(null);
+
+    const run = async () => {
+      let attempt = 0;
+      while (!cancelled && !ac.signal.aborted) {
+        // Fresh (re)connect: resubscribe replays the full log from position 0,
+        // so wipe the store first and rebuild — avoids doubled text deltas.
+        store.getState().clearAllStates();
+        hydrateFromHistory(store, initialMessages);
+
+        let sawTransientError = false;
+        let sawTerminal = false;
+        try {
+          const stream: AsyncGenerator<DistriChatMessage> = agent.resubscribe(taskId, { signal: ac.signal });
+          for await (const evt of stream) {
+            if (cancelled || ac.signal.aborted) break;
+            store.getState().processMessage(evt, true);
+            const type = (evt as { type?: string }).type;
+            const evtTaskId = (evt as { taskId?: string }).taskId;
+            const code = (evt as { data?: { code?: string } }).data?.code;
+            if (type === 'run_error' && code === 'STREAM_ERROR') {
+              sawTransientError = true;
+              const msg = (evt as { data?: { message?: string } }).data?.message ?? 'Stream error';
+              const e = new Error(msg);
+              setError(e);
+              onErrorRef.current?.(e);
+            } else if ((type === 'run_finished' || type === 'run_error') && evtTaskId === taskId) {
+              sawTerminal = true;
+            }
+          }
+        } catch (e) {
+          sawTransientError = true;
+          const err = e instanceof Error ? e : new Error(String(e));
+          setError(err);
+          onErrorRef.current?.(err);
+        }
+
+        if (cancelled || ac.signal.aborted) return;
+        if (sawTerminal || !sawTransientError) {
+          // Terminal frame seen, or the server closed the stream cleanly
+          // (it only closes on the task's own terminal — `until_own_terminal`).
+          setIsTerminal(true);
+          return;
+        }
+        // Transient error → reconnect with capped linear backoff.
+        attempt += 1;
+        if (attempt > MAX_RECONNECTS) {
+          setIsTerminal(true);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 500 * attempt));
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agent, taskId, enabled, reconnectKey, store]);
+
+  const reconnect = useCallback(() => setReconnectKey((k) => k + 1), []);
+  const stop = useCallback(() => abortRef.current?.abort(), []);
+
+  const displayedMessages = useMemo(
+    () => (initialMessages && initialMessages.length > 0 ? [...initialMessages, ...messages] : messages),
+    [initialMessages, messages],
+  );
+
+  return { store, messages: displayedMessages, isStreaming, isTerminal, error, reconnect, stop };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,40 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@types/node@20.19.2)(jsdom@29.0.1)(vite@8.0.7(@types/node@20.19.2)(jiti@2.5.0)(yaml@2.8.0))
 
+  apps/task-stream-demo:
+    dependencies:
+      '@distri/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@distri/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      react:
+        specifier: 19.1.1
+        version: 19.1.1
+      react-dom:
+        specifier: 19.1.1
+        version: 19.1.1(react@19.1.1)
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.2.7)(immer@11.1.4)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.2(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.2)(lightningcss@1.32.0))
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@20.19.2)(lightningcss@1.32.0)
+
   apps/ui:
     dependencies:
       '@distri/components':


### PR DESCRIPTION
## What

Adds a **read-only** way to follow an agent task in distrijs — replay its history and stream the live tail into the same renderers `<Chat>` uses, with no composer and no tool interaction. **No server changes** — A2A `tasks/resubscribe` is already implemented server-side.

## API

**`@distri/core`**
- `DistriClient.resubscribeTask(agentId, taskId)` — wraps `A2AClient.resubscribeTask`.
- `Agent.resubscribe(taskId)` — decoded, read-only twin of `invokeStream` (decode only, no hook/tool side effects; stream errors surface as in-band `run_error`).

**`@distri/react`**
- `useTaskStreaming({ agent, taskId })` — owns a chat store, drives it from `agent.resubscribe`; seed-then-tail, **idempotent clear-and-replay on reconnect** (resubscribe replays the full log, so wipe+replay avoids doubled text deltas), bounded reconnect on transient drop; exposes `{ store, messages, isStreaming, isTerminal, error, reconnect, stop }`.
- `<TaskView>` — turnkey read-only surface exposing the **same renderer surface as `<Chat>`** (`toolRenderers`, `rendering`, `verbose`, …).
- `<ChatMessageList>` — the message-list + fork-anchoring renderer **extracted out of `<Chat>`** so the interactive chat and the read-only view share one implementation (Chat behavior unchanged).

## Consumption levels (documented)
1. `<TaskView>` with renderer props.
2. `useTaskStreaming` + `<ChatMessageList>` in your own shell.
3. `useTaskStreaming` alone → fully custom view.

## Also
- Docs `docs/task-streaming.md` + README section; runnable demo `apps/task-stream-demo`.
- Design specs under `docs/superpowers/specs/` — Phase 1 built; Phase 2 (core reducer extraction) + Phase 3 (Angular) fully specified, not built.

## Tests
- `@distri/core`: 92 pass (4 new). `@distri/react`: 118 pass (8 new). Both type-declaration builds succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)